### PR TITLE
Add generated dashboards to example dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,8 +31,8 @@ clean-demo:
 .PHONY: build-dashboards
 build-dashboards:
 	@echo "Building dashboards"
-	@$(ENVVARS) $(GOCMD) run $(GOMAIN)
-
+	@$(ENVVARS) $(GOCMD) run $(GOMAIN) --output-dir="./examples/dashboards/operator" --output="operator" --project="perses-dev" --datasource="prometheus-datasource"
+	@$(ENVVARS) $(GOCMD) run $(GOMAIN) --output-dir="./examples/dashboards/perses" --output="yaml" --project="perses-dev" --datasource="prometheus-datasource"
 
 .PHONY: deps
 deps:

--- a/examples/dashboards/operator/alertmanager-overview.yaml
+++ b/examples/dashboards/operator/alertmanager-overview.yaml
@@ -1,0 +1,255 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: alertmanager-overview
+    app.kubernetes.io/name: perses-dashboard
+    app.kubernetes.io/part-of: perses-operator
+  name: alertmanager-overview
+  namespace: perses-dev
+spec:
+  display:
+    name: Alertmanager / Overview
+  duration: 1h
+  layouts:
+  - kind: Grid
+    spec:
+      display:
+        title: Alerts
+      items:
+      - content:
+          $ref: '#/spec/panels/0_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/0_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Notifications
+      items:
+      - content:
+          $ref: '#/spec/panels/1_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/1_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  panels:
+    "0_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows current alerts in Alertmanager
+          name: Alerts
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: sum by (instance) (alertmanager_alerts{job=~"$job"})
+                seriesNameFormat: '{{instance}} - Alertmanager - Alerts'
+    "0_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows alert receive rate in Alertmanager
+          name: Alerts receive rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: sum by (job, instance) (rate(alertmanager_alerts_received_total{job=~"$job"}[5m]))
+                seriesNameFormat: '{{instance}} - Alertmanager - Received'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: sum by (job, instance) (rate(alertmanager_alerts_invalid_total{job=~"$job"}[5m]))
+                seriesNameFormat: '{{instance}} - Alertmanager - Invalid'
+    "1_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows notification send rate for the Alertmanager
+          name: Notifications Send Rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (integration, instance) (
+                    rate(alertmanager_notifications_total{integration=~"$integration",job=~"$job"}[5m])
+                  )
+                seriesNameFormat: '{{instance}} - {{integration}} - Total'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (integration, instance) (
+                    rate(alertmanager_notifications_failed_total{integration=~"$integration",job=~"$job"}[5m])
+                  )
+                seriesNameFormat: '{{instance}} - {{integration}} - Failed'
+    "1_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows notification latency for the Alertmanager
+          name: Notification Duration
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.99,
+                    sum by (le, integration, instance) (
+                      rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                    )
+                  )
+                seriesNameFormat: '{{instance}} - {{integration}} - 99th Percentile'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.5,
+                    sum by (le, integration, instance) (
+                      rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                    )
+                  )
+                seriesNameFormat: '{{instance}} - {{integration}} - Median'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    sum by (integration, instance) (
+                      rate(alertmanager_notification_latency_seconds_sum{integration=~"$integration",job=~"$job"}[5m])
+                    )
+                  /
+                    sum by (integration, instance) (
+                      rate(alertmanager_notification_latency_seconds_count{integration=~"$integration",job=~"$job"}[5m])
+                    )
+                seriesNameFormat: '{{instance}} - {{integration}} - Average'
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: job
+      name: job
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: job
+          matchers:
+          - alertmanager_alerts{}
+  - kind: ListVariable
+    spec:
+      allowAllValue: true
+      allowMultiple: true
+      display:
+        hidden: false
+        name: integration
+      name: integration
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: integration
+          matchers:
+          - alertmanager_notifications_total{job="$job"}
+status: {}

--- a/examples/dashboards/operator/node-exporter-cluster-use-method.yaml
+++ b/examples/dashboards/operator/node-exporter-cluster-use-method.yaml
@@ -1,0 +1,437 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: node-exporter-cluster-use-method
+    app.kubernetes.io/name: perses-dashboard
+    app.kubernetes.io/part-of: perses-operator
+  name: node-exporter-cluster-use-method
+  namespace: perses-dev
+spec:
+  display:
+    name: Node Exporter / USE Method / Cluster
+  duration: 1h
+  layouts:
+  - kind: Grid
+    spec:
+      display:
+        title: CPU
+      items:
+      - content:
+          $ref: '#/spec/panels/0_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/0_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Memory
+      items:
+      - content:
+          $ref: '#/spec/panels/1_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/1_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Network
+      items:
+      - content:
+          $ref: '#/spec/panels/2_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Disk IO
+      items:
+      - content:
+          $ref: '#/spec/panels/3_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/3_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Disk Space
+      items:
+      - content:
+          $ref: '#/spec/panels/4_0'
+        height: 6
+        width: 24
+        x: 0
+        "y": 0
+  panels:
+    "0_0":
+      kind: Panel
+      spec:
+        display:
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    (
+                        (
+                            instance:node_cpu_utilisation:rate5m{instance=~"$instance",job="node"}
+                          *
+                            instance:node_num_cpu:sum{instance=~"$instance",job="node"}
+                        )
+                      !=
+                        0
+                    )
+                  /
+                    scalar(sum(instance:node_num_cpu:sum{instance=~"$instance",job="node"}))
+                seriesNameFormat: '{{instance}}'
+    "0_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows CPU saturation metrics across cluster nodes
+          name: CPU Saturation (Load1 per CPU)
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    (
+                        instance:node_load1_per_cpu:ratio{instance=~"$instance",job="node"}
+                      /
+                        scalar(count(instance:node_load1_per_cpu:ratio{instance=~"$instance",job="node"}))
+                    )
+                  !=
+                    0
+                seriesNameFormat: '{{instance}}'
+    "1_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows memory utilization percentage across cluster nodes
+          name: Memory Utilisation
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    (
+                        instance:node_memory_utilisation:ratio{instance=~"$instance",job="node"}
+                      /
+                        scalar(count(instance:node_memory_utilisation:ratio{instance=~"$instance",job="node"}))
+                    )
+                  !=
+                    0
+                seriesNameFormat: '{{instance}}'
+    "1_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows memory saturation through page fault metrics
+          name: Memory Saturation (Major Page Faults)
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: reads/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: instance:node_vmstat_pgmajfault:rate5m{instance=~"$instance",job="node"}
+                seriesNameFormat: '{{instance}}'
+    "2_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows network utilization in bytes
+          name: Network Utilisation (Bytes Receive/Transmit)
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: instance:node_network_receive_bytes_excluding_lo:rate5m{instance=~"$instance",job="node"}
+                  != 0
+                seriesNameFormat: '{{instance}} - Network - Received'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: instance:node_network_transmit_bytes_excluding_lo:rate5m{instance=~"$instance",job="node"}
+                  != 0
+                seriesNameFormat: '{{instance}} - Network - Transmitted'
+    "2_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows network saturation through drop metrics
+          name: Network Saturation (Drops Receive/Transmit)
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: instance:node_network_receive_drop_excluding_lo:rate5m{instance=~"$instance",job="node"}
+                  != 0
+                seriesNameFormat: '{{instance}} - Network - Received'
+    "3_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows disk I/O utilization across cluster nodes
+          name: Disk IO Utilisation
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    (
+                        instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}
+                      /
+                        scalar(count(instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}))
+                    )
+                  !=
+                    0
+                seriesNameFormat: '{{instance}}'
+    "3_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows disk I/O saturation metrics
+          name: Disk IO Saturation
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    (
+                        instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}
+                      /
+                        scalar(count(instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}))
+                    )
+                  !=
+                    0
+                seriesNameFormat: '{{instance}}'
+    "4_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows disk space utilization metrics
+          name: Disk Space Utilisation
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    sum without (device) (
+                      max without (fstype, mountpoint) (
+                          (
+                              node_filesystem_size_bytes{fstype!="",instance=~"$instance",job="node",mountpoint!=""}
+                            -
+                              node_filesystem_avail_bytes{fstype!="",instance=~"$instance",job="node",mountpoint!=""}
+                          )
+                        !=
+                          0
+                      )
+                    )
+                  /
+                    scalar(
+                      sum(
+                        max without (fstype, mountpoint) (
+                          node_filesystem_size_bytes{fstype!="",instance=~"$instance",job="node",mountpoint!=""}
+                        )
+                      )
+                    )
+                seriesNameFormat: '{{instance}}'
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: true
+      allowMultiple: true
+      display:
+        hidden: false
+        name: instance
+      name: instance
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: instance
+          matchers:
+          - node_uname_info{job="node",sysname!="Darwin"}
+status: {}

--- a/examples/dashboards/operator/node-exporter-nodes.yaml
+++ b/examples/dashboards/operator/node-exporter-nodes.yaml
@@ -1,0 +1,409 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: node-exporter-nodes
+    app.kubernetes.io/name: perses-dashboard
+    app.kubernetes.io/part-of: perses-operator
+  name: node-exporter-nodes
+  namespace: perses-dev
+spec:
+  display:
+    name: Node Exporter / Nodes
+  duration: 1h
+  layouts:
+  - kind: Grid
+    spec:
+      display:
+        title: CPU
+      items:
+      - content:
+          $ref: '#/spec/panels/0_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/0_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Memory
+      items:
+      - content:
+          $ref: '#/spec/panels/1_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/1_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Disk
+      items:
+      - content:
+          $ref: '#/spec/panels/2_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Network
+      items:
+      - content:
+          $ref: '#/spec/panels/3_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/3_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  panels:
+    "0_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows CPU utilization percentage across cluster nodes
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  (
+                      (
+                          1
+                        -
+                          sum without (mode) (
+                            rate(node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[5m])
+                          )
+                      )
+                    / ignoring (cpu) group_left ()
+                      count without (cpu, mode) (node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                  )
+                seriesNameFormat: '{{device}} - CPU - Usage'
+    "0_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows CPU utilization metrics
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: node_load1{instance="$instance",job="node"}
+                seriesNameFormat: CPU - 1m Average
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: node_load5{instance="$instance",job="node"}
+                seriesNameFormat: CPU - 5m Average
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: node_load15{instance="$instance",job="node"}
+                seriesNameFormat: CPU - 15m Average
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: count(node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                seriesNameFormat: CPU - Logical Cores
+    "1_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows memory utilization metrics
+          name: Memory Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                shortValues: true
+                unit: bytes
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: node_memory_Buffers_bytes{instance="$instance",job="node"}
+                seriesNameFormat: Memory - Buffers
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: node_memory_Cached_bytes{instance="$instance",job="node"}
+                seriesNameFormat: Memory - Cached
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: node_memory_MemFree_bytes{instance="$instance",job="node"}
+                seriesNameFormat: Memory - Free
+    "1_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows memory utilization across nodes
+          name: Memory Usage
+        plugin:
+          kind: GaugeChart
+          spec:
+            calculation: last
+            format:
+              unit: percent
+            thresholds:
+              defaultColor: green
+              mode: absolute
+              steps:
+              - color: orange
+                value: 80
+              - color: red
+                value: 90
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    100
+                  -
+                    (
+                          avg(node_memory_MemAvailable_bytes{instance="$instance",job="node"})
+                        /
+                          avg(node_memory_MemTotal_bytes{instance="$instance",job="node"})
+                      *
+                        100
+                    )
+                seriesNameFormat: Memory - Usage
+    "2_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows disk I/O metrics in bytes
+          name: Disk I/O Bytes
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: bytes
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[5m])
+                seriesNameFormat: '{{device}} - Disk - Usage'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                seriesNameFormat: '{{device}} - Disk - Written'
+    "2_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows disk I/O duration metrics
+          name: Disk I/O Seconds
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                seriesNameFormat: '{{device}} - Disk - IO Time'
+    "3_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows network received bytes metrics
+          name: Network Received
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                seriesNameFormat: '{{device}} - Network - Received'
+    "3_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows network transmitted bytes metrics
+          name: Network Transmitted
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(node_network_transmit_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                seriesNameFormat: '{{device}} - Network - Transmitted'
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: true
+      allowMultiple: false
+      display:
+        hidden: false
+        name: instance
+      name: instance
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: instance
+          matchers:
+          - node_uname_info{job="node",sysname!="Darwin"}
+status: {}

--- a/examples/dashboards/operator/prometheus-overview.yaml
+++ b/examples/dashboards/operator/prometheus-overview.yaml
@@ -1,0 +1,456 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: prometheus-overview
+    app.kubernetes.io/name: perses-dashboard
+    app.kubernetes.io/part-of: perses-operator
+  name: prometheus-overview
+  namespace: perses-dev
+spec:
+  display:
+    name: Prometheus / Overview
+  duration: 1h
+  layouts:
+  - kind: Grid
+    spec:
+      display:
+        title: Prometheus Stats
+      items:
+      - content:
+          $ref: '#/spec/panels/0_0'
+        height: 6
+        width: 24
+        x: 0
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Discovery
+      items:
+      - content:
+          $ref: '#/spec/panels/1_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/1_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Retrieval
+      items:
+      - content:
+          $ref: '#/spec/panels/2_0'
+        height: 6
+        width: 8
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_1'
+        height: 6
+        width: 8
+        x: 8
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_2'
+        height: 6
+        width: 8
+        x: 16
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Storage
+      items:
+      - content:
+          $ref: '#/spec/panels/3_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/3_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Query
+      items:
+      - content:
+          $ref: '#/spec/panels/4_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/4_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  panels:
+    "0_0":
+      kind: Panel
+      spec:
+        display:
+          name: Prometheus Stats
+        plugin:
+          kind: Table
+          spec:
+            columnSettings:
+            - header: Job
+              name: job
+            - header: Instance
+              name: instance
+            - header: Version
+              name: version
+            - hide: true
+              name: value
+            - hide: true
+              name: timestamp
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: count by (job, instance, version) (prometheus_build_info{instance=~"$instance",job=~"$job"})
+    "1_0":
+      kind: Panel
+      spec:
+        display:
+          description: Monitors target synchronization time for Prometheus instances
+          name: Target Sync
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (job, scrape_job, instance) (
+                    rate(prometheus_target_sync_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                  )
+                seriesNameFormat: '{{job}} - {{instance}} - Metrics'
+    "1_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows discovered targets across Prometheus instances
+          name: Targets
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: sum by (job, instance) (prometheus_sd_discovered_targets{instance=~"$instance",job=~"$job"})
+                seriesNameFormat: '{{job}} - {{instance}} - Metrics'
+    "2_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows average interval between scrapes for Prometheus targets
+          name: Average Scrape Interval Duration
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    rate(prometheus_target_interval_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                  /
+                    rate(prometheus_target_interval_length_seconds_count{instance=~"$instance",job=~"$job"}[5m])
+                seriesNameFormat: '{{job}} - {{instance}} - {{interval}} Configured'
+    "2_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows scrape failure metrics for Prometheus targets
+          name: Scrape failures
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (job, instance) (
+                    rate(
+                      prometheus_target_scrapes_exceeded_body_size_limit_total{instance=~"$instance",job=~"$job"}[1m]
+                    )
+                  )
+                seriesNameFormat: 'exceeded body size limit: {{job}} - {{instance}}
+                  - Metrics'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (job, instance) (
+                    rate(prometheus_target_scrapes_exceeded_sample_limit_total{instance=~"$instance",job=~"$job"}[1m])
+                  )
+                seriesNameFormat: 'exceeded sample limit: {{job}} - {{instance}} -
+                  Metrics'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (job, instance) (
+                    rate(
+                      prometheus_target_scrapes_sample_duplicate_timestamp_total{instance=~"$instance",job=~"$job"}[1m]
+                    )
+                  )
+                seriesNameFormat: 'duplicate timestamp: {{job}} - {{instance}} - Metrics'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (job, instance) (
+                    rate(prometheus_target_scrapes_sample_out_of_bounds_total{instance=~"$instance",job=~"$job"}[1m])
+                  )
+                seriesNameFormat: 'out of bounds: {{job}} - {{instance}} - Metrics'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (job, instance) (
+                    rate(prometheus_target_scrapes_sample_out_of_order_total{instance=~"$instance",job=~"$job"}[1m])
+                  )
+                seriesNameFormat: 'out of order: {{job}} - {{instance}} - Metrics'
+    "2_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows rate of samples appended to Prometheus TSDB
+          name: Appended Samples
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(prometheus_tsdb_head_samples_appended_total{instance=~"$instance",job=~"$job"}[5m])
+                seriesNameFormat: '{{job}} - {{instance}} - {{remote_name}} - {{url}}'
+    "3_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows number of series in Prometheus TSDB head
+          name: Head Series
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_tsdb_head_series{instance=~"$instance",job=~"$job"}
+                seriesNameFormat: '{{job}} - {{instance}} - Head Series'
+    "3_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows number of chunks in Prometheus TSDB head
+          name: Head Chunks
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_tsdb_head_chunks{instance=~"$instance",job=~"$job"}
+                seriesNameFormat: '{{job}} - {{instance}} - Head Chunks'
+    "4_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows Prometheus query rate metrics
+          name: Query Rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  rate(
+                    prometheus_engine_query_duration_seconds_count{instance=~"$instance",job=~"$job",slice="inner_eval"}[5m]
+                  )
+                seriesNameFormat: '{{job}} - {{instance}} - Query Rate'
+    "4_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows duration of different Prometheus query stages
+          name: Stage Duration
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  max by (slice) (
+                    prometheus_engine_query_duration_seconds{instance=~"$instance",job=~"$job",quantile="0.9"}
+                  )
+                seriesNameFormat: '{{slice}} - Duration'
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: job
+      name: job
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: job
+          matchers:
+          - prometheus_build_info{}
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: instance
+      name: instance
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: instance
+          matchers:
+          - prometheus_build_info{job="$job"}
+status: {}

--- a/examples/dashboards/operator/prometheus-remote-write.yaml
+++ b/examples/dashboards/operator/prometheus-remote-write.yaml
@@ -1,0 +1,560 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: prometheus-remote-write
+    app.kubernetes.io/name: perses-dashboard
+    app.kubernetes.io/part-of: perses-operator
+  name: prometheus-remote-write
+  namespace: perses-dev
+spec:
+  display:
+    name: Prometheus / Remote Write
+  duration: 1h
+  layouts:
+  - kind: Grid
+    spec:
+      display:
+        title: Timestamps
+      items:
+      - content:
+          $ref: '#/spec/panels/0_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/0_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Samples
+      items:
+      - content:
+          $ref: '#/spec/panels/1_0'
+        height: 6
+        width: 24
+        x: 0
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Shards
+      items:
+      - content:
+          $ref: '#/spec/panels/2_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_2'
+        height: 6
+        width: 12
+        x: 0
+        "y": 6
+      - content:
+          $ref: '#/spec/panels/2_3'
+        height: 6
+        width: 12
+        x: 12
+        "y": 6
+  - kind: Grid
+    spec:
+      display:
+        title: Shard Details
+      items:
+      - content:
+          $ref: '#/spec/panels/3_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/3_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Segments
+      items:
+      - content:
+          $ref: '#/spec/panels/4_0'
+        height: 6
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/4_1'
+        height: 6
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Misc. Rates
+      items:
+      - content:
+          $ref: '#/spec/panels/5_0'
+        height: 6
+        width: 6
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/5_1'
+        height: 6
+        width: 6
+        x: 6
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/5_2'
+        height: 6
+        width: 6
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/5_3'
+        height: 6
+        width: 6
+        x: 18
+        "y": 0
+  panels:
+    "0_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows timestamp lag in remote storage
+          name: Timestamp Lag
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  (
+                      prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}
+                    - ignoring (remote_name, url) group_right (instance)
+                      (
+                          prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}
+                        !=
+                          0
+                      )
+                  )
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Segment'
+    "0_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows rate metrics over 5 minute intervals
+          name: Rate[5m]
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  clamp_min(
+                      rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}[5m])
+                    - ignoring (remote_name, url) group_right (instance)
+                      rate(
+                        prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}[5m]
+                      ),
+                    0
+                  )
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "1_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows rate of samples in remote storage
+          name: Rate, in vs. succeeded or dropped [5m]
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                      rate(prometheus_remote_storage_samples_in_total{instance=~"$instance"}[5m])
+                    - ignoring (remote_name, url) group_right (instance)
+                      (
+                          rate(prometheus_remote_storage_succeeded_samples_total{instance=~"$instance",url="$url"}[5m])
+                        or
+                          rate(prometheus_remote_storage_samples_total{instance=~"$instance",url="$url"}[5m])
+                      )
+                  -
+                    (
+                        rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                      or
+                        rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                    )
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "2_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows current number of shards in remote storage
+          name: Current Shards
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_remote_storage_shards{instance=~"$instance",url="$url"}
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "2_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows desired number of shards in remote storage
+          name: Desired Shards
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_remote_storage_shards_desired{instance=~"$instance",url="$url"}
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "2_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows maximum number of shards in remote storage
+          name: Max Shards
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_remote_storage_shards_max{instance=~"$instance",url="$url"}
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "2_3":
+      kind: Panel
+      spec:
+        display:
+          description: Shows minimum number of shards in remote storage
+          name: Min Shards
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_remote_storage_shards_min{instance=~"$instance",url="$url"}
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "3_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows shard capacity in remote storage
+          name: Shard Capacity
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_remote_storage_shard_capacity{instance=~"$instance",url="$url"}
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "3_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows number of pending samples in remote storage
+          name: Pending Samples
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    prometheus_remote_storage_pending_samples{instance=~"$instance",url="$url"}
+                  or
+                    prometheus_remote_storage_samples_pending{instance=~"$instance",url="$url"}
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "4_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows current TSDB WAL segment
+          name: TSDB Current Segment
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_tsdb_wal_segment_current{instance=~"$instance"}
+                seriesNameFormat: '{{instance}} - Segment - Metrics'
+    "4_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows current remote write WAL segment
+          name: Remote Write Current Segment
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: prometheus_wal_watcher_current_segment{instance=~"$instance"}
+                seriesNameFormat: '{{instance}} - Segment - Metrics'
+    "5_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows rate of dropped samples in remote storage
+          name: Dropped Samples Rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                  or
+                    rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "5_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows rate of failed samples in remote storage
+          name: Failed Samples
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    rate(prometheus_remote_storage_failed_samples_total{instance=~"$instance",url="$url"}[5m])
+                  or
+                    rate(prometheus_remote_storage_samples_failed_total{instance=~"$instance",url="$url"}[5m])
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "5_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows rate of retried samples in remote storage
+          name: Retried Samples
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    rate(prometheus_remote_storage_retried_samples_total{instance=~"$instance",url=~"$url"}[5m])
+                  or
+                    rate(prometheus_remote_storage_samples_retried_total{instance=~"$instance",url=~"$url"}[5m])
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    "5_3":
+      kind: Panel
+      spec:
+        display:
+          description: Shows rate of enqueue retries in remote storage
+          name: Enqueue Retries
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(prometheus_remote_storage_enqueue_retries_total{instance=~"$instance",url=~"$url"}[5m])
+                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: instance
+      name: instance
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: instance
+          matchers:
+          - prometheus_remote_storage_shards{}
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: url
+      name: url
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: url
+          matchers:
+          - prometheus_remote_storage_shards{instance="$instance"}
+status: {}

--- a/examples/dashboards/perses/alertmanager-overview.yaml
+++ b/examples/dashboards/perses/alertmanager-overview.yaml
@@ -1,0 +1,250 @@
+kind: Dashboard
+metadata:
+    name: alertmanager-overview
+    createdAt: 0001-01-01T00:00:00Z
+    updatedAt: 0001-01-01T00:00:00Z
+    version: 0
+    project: perses-dev
+spec:
+    display:
+        name: Alertmanager / Overview
+    variables:
+        - kind: ListVariable
+          spec:
+            display:
+                name: job
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: job
+                    matchers:
+                        - alertmanager_alerts{}
+            name: job
+        - kind: ListVariable
+          spec:
+            display:
+                name: integration
+                hidden: false
+            allowAllValue: true
+            allowMultiple: true
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: integration
+                    matchers:
+                        - alertmanager_notifications_total{job="$job"}
+            name: integration
+    panels:
+        "0_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Alerts
+                    description: Shows current alerts in Alertmanager
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: sum by (instance) (alertmanager_alerts{job=~"$job"})
+                                seriesNameFormat: '{{instance}} - Alertmanager - Alerts'
+        "0_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Alerts receive rate
+                    description: Shows alert receive rate in Alertmanager
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: sum by (job, instance) (rate(alertmanager_alerts_received_total{job=~"$job"}[5m]))
+                                seriesNameFormat: '{{instance}} - Alertmanager - Received'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: sum by (job, instance) (rate(alertmanager_alerts_invalid_total{job=~"$job"}[5m]))
+                                seriesNameFormat: '{{instance}} - Alertmanager - Invalid'
+        "1_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Notifications Send Rate
+                    description: Shows notification send rate for the Alertmanager
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (integration, instance) (
+                                      rate(alertmanager_notifications_total{integration=~"$integration",job=~"$job"}[5m])
+                                    )
+                                seriesNameFormat: '{{instance}} - {{integration}} - Total'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (integration, instance) (
+                                      rate(alertmanager_notifications_failed_total{integration=~"$integration",job=~"$job"}[5m])
+                                    )
+                                seriesNameFormat: '{{instance}} - {{integration}} - Failed'
+        "1_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Notification Duration
+                    description: Shows notification latency for the Alertmanager
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: seconds
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.99,
+                                      sum by (le, integration, instance) (
+                                        rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                                      )
+                                    )
+                                seriesNameFormat: '{{instance}} - {{integration}} - 99th Percentile'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.5,
+                                      sum by (le, integration, instance) (
+                                        rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                                      )
+                                    )
+                                seriesNameFormat: '{{instance}} - {{integration}} - Median'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      sum by (integration, instance) (
+                                        rate(alertmanager_notification_latency_seconds_sum{integration=~"$integration",job=~"$job"}[5m])
+                                      )
+                                    /
+                                      sum by (integration, instance) (
+                                        rate(alertmanager_notification_latency_seconds_count{integration=~"$integration",job=~"$job"}[5m])
+                                      )
+                                seriesNameFormat: '{{instance}} - {{integration}} - Average'
+    layouts:
+        - kind: Grid
+          spec:
+            display:
+                title: Alerts
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Notifications
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_1'
+    duration: 1h

--- a/examples/dashboards/perses/node-exporter-cluster-use-method.yaml
+++ b/examples/dashboards/perses/node-exporter-cluster-use-method.yaml
@@ -1,0 +1,429 @@
+kind: Dashboard
+metadata:
+    name: node-exporter-cluster-use-method
+    createdAt: 0001-01-01T00:00:00Z
+    updatedAt: 0001-01-01T00:00:00Z
+    version: 0
+    project: perses-dev
+spec:
+    display:
+        name: Node Exporter / USE Method / Cluster
+    variables:
+        - kind: ListVariable
+          spec:
+            display:
+                name: instance
+                hidden: false
+            allowAllValue: true
+            allowMultiple: true
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: instance
+                    matchers:
+                        - node_uname_info{job="node",sysname!="Darwin"}
+            name: instance
+    panels:
+        "0_0":
+            kind: Panel
+            spec:
+                display:
+                    name: CPU Usage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      (
+                                          (
+                                              instance:node_cpu_utilisation:rate5m{instance=~"$instance",job="node"}
+                                            *
+                                              instance:node_num_cpu:sum{instance=~"$instance",job="node"}
+                                          )
+                                        !=
+                                          0
+                                      )
+                                    /
+                                      scalar(sum(instance:node_num_cpu:sum{instance=~"$instance",job="node"}))
+                                seriesNameFormat: '{{instance}}'
+        "0_1":
+            kind: Panel
+            spec:
+                display:
+                    name: CPU Saturation (Load1 per CPU)
+                    description: Shows CPU saturation metrics across cluster nodes
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      (
+                                          instance:node_load1_per_cpu:ratio{instance=~"$instance",job="node"}
+                                        /
+                                          scalar(count(instance:node_load1_per_cpu:ratio{instance=~"$instance",job="node"}))
+                                      )
+                                    !=
+                                      0
+                                seriesNameFormat: '{{instance}}'
+        "1_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Memory Utilisation
+                    description: Shows memory utilization percentage across cluster nodes
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      (
+                                          instance:node_memory_utilisation:ratio{instance=~"$instance",job="node"}
+                                        /
+                                          scalar(count(instance:node_memory_utilisation:ratio{instance=~"$instance",job="node"}))
+                                      )
+                                    !=
+                                      0
+                                seriesNameFormat: '{{instance}}'
+        "1_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Memory Saturation (Major Page Faults)
+                    description: Shows memory saturation through page fault metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: reads/sec
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: instance:node_vmstat_pgmajfault:rate5m{instance=~"$instance",job="node"}
+                                seriesNameFormat: '{{instance}}'
+        "2_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Network Utilisation (Bytes Receive/Transmit)
+                    description: Shows network utilization in bytes
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: instance:node_network_receive_bytes_excluding_lo:rate5m{instance=~"$instance",job="node"} != 0
+                                seriesNameFormat: '{{instance}} - Network - Received'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: instance:node_network_transmit_bytes_excluding_lo:rate5m{instance=~"$instance",job="node"} != 0
+                                seriesNameFormat: '{{instance}} - Network - Transmitted'
+        "2_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Network Saturation (Drops Receive/Transmit)
+                    description: Shows network saturation through drop metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: instance:node_network_receive_drop_excluding_lo:rate5m{instance=~"$instance",job="node"} != 0
+                                seriesNameFormat: '{{instance}} - Network - Received'
+        "3_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Disk IO Utilisation
+                    description: Shows disk I/O utilization across cluster nodes
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      (
+                                          instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}
+                                        /
+                                          scalar(count(instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}))
+                                      )
+                                    !=
+                                      0
+                                seriesNameFormat: '{{instance}}'
+        "3_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Disk IO Saturation
+                    description: Shows disk I/O saturation metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      (
+                                          instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}
+                                        /
+                                          scalar(count(instance_device:node_disk_io_time_seconds:rate5m{instance=~"$instance",job="node"}))
+                                      )
+                                    !=
+                                      0
+                                seriesNameFormat: '{{instance}}'
+        "4_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Disk Space Utilisation
+                    description: Shows disk space utilization metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      sum without (device) (
+                                        max without (fstype, mountpoint) (
+                                            (
+                                                node_filesystem_size_bytes{fstype!="",instance=~"$instance",job="node",mountpoint!=""}
+                                              -
+                                                node_filesystem_avail_bytes{fstype!="",instance=~"$instance",job="node",mountpoint!=""}
+                                            )
+                                          !=
+                                            0
+                                        )
+                                      )
+                                    /
+                                      scalar(
+                                        sum(
+                                          max without (fstype, mountpoint) (
+                                            node_filesystem_size_bytes{fstype!="",instance=~"$instance",job="node",mountpoint!=""}
+                                          )
+                                        )
+                                      )
+                                seriesNameFormat: '{{instance}}'
+    layouts:
+        - kind: Grid
+          spec:
+            display:
+                title: CPU
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Memory
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Network
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Disk IO
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Disk Space
+            items:
+                - x: 0
+                  "y": 0
+                  width: 24
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/4_0'
+    duration: 1h

--- a/examples/dashboards/perses/node-exporter-nodes.yaml
+++ b/examples/dashboards/perses/node-exporter-nodes.yaml
@@ -1,0 +1,404 @@
+kind: Dashboard
+metadata:
+    name: node-exporter-nodes
+    createdAt: 0001-01-01T00:00:00Z
+    updatedAt: 0001-01-01T00:00:00Z
+    version: 0
+    project: perses-dev
+spec:
+    display:
+        name: Node Exporter / Nodes
+    variables:
+        - kind: ListVariable
+          spec:
+            display:
+                name: instance
+                hidden: false
+            allowAllValue: true
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: instance
+                    matchers:
+                        - node_uname_info{job="node",sysname!="Darwin"}
+            name: instance
+    panels:
+        "0_0":
+            kind: Panel
+            spec:
+                display:
+                    name: CPU Usage
+                    description: Shows CPU utilization percentage across cluster nodes
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    (
+                                        (
+                                            1
+                                          -
+                                            sum without (mode) (
+                                              rate(node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[5m])
+                                            )
+                                        )
+                                      / ignoring (cpu) group_left ()
+                                        count without (cpu, mode) (node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                                    )
+                                seriesNameFormat: '{{device}} - CPU - Usage'
+        "0_1":
+            kind: Panel
+            spec:
+                display:
+                    name: CPU Usage
+                    description: Shows CPU utilization metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: node_load1{instance="$instance",job="node"}
+                                seriesNameFormat: CPU - 1m Average
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: node_load5{instance="$instance",job="node"}
+                                seriesNameFormat: CPU - 5m Average
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: node_load15{instance="$instance",job="node"}
+                                seriesNameFormat: CPU - 15m Average
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: count(node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                                seriesNameFormat: CPU - Logical Cores
+        "1_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Memory Usage
+                    description: Shows memory utilization metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes
+                                shortValues: true
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: node_memory_Buffers_bytes{instance="$instance",job="node"}
+                                seriesNameFormat: Memory - Buffers
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: node_memory_Cached_bytes{instance="$instance",job="node"}
+                                seriesNameFormat: Memory - Cached
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: node_memory_MemFree_bytes{instance="$instance",job="node"}
+                                seriesNameFormat: Memory - Free
+        "1_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Memory Usage
+                    description: Shows memory utilization across nodes
+                plugin:
+                    kind: GaugeChart
+                    spec:
+                        calculation: last
+                        format:
+                            unit: percent
+                        thresholds:
+                            mode: absolute
+                            defaultColor: green
+                            steps:
+                                - value: 80
+                                  color: orange
+                                - value: 90
+                                  color: red
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      100
+                                    -
+                                      (
+                                            avg(node_memory_MemAvailable_bytes{instance="$instance",job="node"})
+                                          /
+                                            avg(node_memory_MemTotal_bytes{instance="$instance",job="node"})
+                                        *
+                                          100
+                                      )
+                                seriesNameFormat: Memory - Usage
+        "2_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Disk I/O Bytes
+                    description: Shows disk I/O metrics in bytes
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[5m])
+                                seriesNameFormat: '{{device}} - Disk - Usage'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                                seriesNameFormat: '{{device}} - Disk - Written'
+        "2_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Disk I/O Seconds
+                    description: Shows disk I/O duration metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: seconds
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                                seriesNameFormat: '{{device}} - Disk - IO Time'
+        "3_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Network Received
+                    description: Shows network received bytes metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                                seriesNameFormat: '{{device}} - Network - Received'
+        "3_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Network Transmitted
+                    description: Shows network transmitted bytes metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(node_network_transmit_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                                seriesNameFormat: '{{device}} - Network - Transmitted'
+    layouts:
+        - kind: Grid
+          spec:
+            display:
+                title: CPU
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Memory
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Disk
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Network
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_1'
+    duration: 1h

--- a/examples/dashboards/perses/prometheus-overview.yaml
+++ b/examples/dashboards/perses/prometheus-overview.yaml
@@ -1,0 +1,449 @@
+kind: Dashboard
+metadata:
+    name: prometheus-overview
+    createdAt: 0001-01-01T00:00:00Z
+    updatedAt: 0001-01-01T00:00:00Z
+    version: 0
+    project: perses-dev
+spec:
+    display:
+        name: Prometheus / Overview
+    variables:
+        - kind: ListVariable
+          spec:
+            display:
+                name: job
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: job
+                    matchers:
+                        - prometheus_build_info{}
+            name: job
+        - kind: ListVariable
+          spec:
+            display:
+                name: instance
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: instance
+                    matchers:
+                        - prometheus_build_info{job="$job"}
+            name: instance
+    panels:
+        "0_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Prometheus Stats
+                plugin:
+                    kind: Table
+                    spec:
+                        columnSettings:
+                            - name: job
+                              header: Job
+                            - name: instance
+                              header: Instance
+                            - name: version
+                              header: Version
+                            - name: value
+                              hide: true
+                            - name: timestamp
+                              hide: true
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: count by (job, instance, version) (prometheus_build_info{instance=~"$instance",job=~"$job"})
+        "1_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Target Sync
+                    description: Monitors target synchronization time for Prometheus instances
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                        yAxis:
+                            format:
+                                unit: seconds
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (job, scrape_job, instance) (
+                                      rate(prometheus_target_sync_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                                    )
+                                seriesNameFormat: '{{job}} - {{instance}} - Metrics'
+        "1_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Targets
+                    description: Shows discovered targets across Prometheus instances
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: sum by (job, instance) (prometheus_sd_discovered_targets{instance=~"$instance",job=~"$job"})
+                                seriesNameFormat: '{{job}} - {{instance}} - Metrics'
+        "2_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Average Scrape Interval Duration
+                    description: Shows average interval between scrapes for Prometheus targets
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                        yAxis:
+                            format:
+                                unit: seconds
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      rate(prometheus_target_interval_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                                    /
+                                      rate(prometheus_target_interval_length_seconds_count{instance=~"$instance",job=~"$job"}[5m])
+                                seriesNameFormat: '{{job}} - {{instance}} - {{interval}} Configured'
+        "2_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Scrape failures
+                    description: Shows scrape failure metrics for Prometheus targets
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (job, instance) (
+                                      rate(
+                                        prometheus_target_scrapes_exceeded_body_size_limit_total{instance=~"$instance",job=~"$job"}[1m]
+                                      )
+                                    )
+                                seriesNameFormat: 'exceeded body size limit: {{job}} - {{instance}} - Metrics'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (job, instance) (
+                                      rate(prometheus_target_scrapes_exceeded_sample_limit_total{instance=~"$instance",job=~"$job"}[1m])
+                                    )
+                                seriesNameFormat: 'exceeded sample limit: {{job}} - {{instance}} - Metrics'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (job, instance) (
+                                      rate(
+                                        prometheus_target_scrapes_sample_duplicate_timestamp_total{instance=~"$instance",job=~"$job"}[1m]
+                                      )
+                                    )
+                                seriesNameFormat: 'duplicate timestamp: {{job}} - {{instance}} - Metrics'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (job, instance) (
+                                      rate(prometheus_target_scrapes_sample_out_of_bounds_total{instance=~"$instance",job=~"$job"}[1m])
+                                    )
+                                seriesNameFormat: 'out of bounds: {{job}} - {{instance}} - Metrics'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (job, instance) (
+                                      rate(prometheus_target_scrapes_sample_out_of_order_total{instance=~"$instance",job=~"$job"}[1m])
+                                    )
+                                seriesNameFormat: 'out of order: {{job}} - {{instance}} - Metrics'
+        "2_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Appended Samples
+                    description: Shows rate of samples appended to Prometheus TSDB
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(prometheus_tsdb_head_samples_appended_total{instance=~"$instance",job=~"$job"}[5m])
+                                seriesNameFormat: '{{job}} - {{instance}} - {{remote_name}} - {{url}}'
+        "3_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Head Series
+                    description: Shows number of series in Prometheus TSDB head
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_tsdb_head_series{instance=~"$instance",job=~"$job"}
+                                seriesNameFormat: '{{job}} - {{instance}} - Head Series'
+        "3_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Head Chunks
+                    description: Shows number of chunks in Prometheus TSDB head
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_tsdb_head_chunks{instance=~"$instance",job=~"$job"}
+                                seriesNameFormat: '{{job}} - {{instance}} - Head Chunks'
+        "4_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Query Rate
+                    description: Shows Prometheus query rate metrics
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    rate(
+                                      prometheus_engine_query_duration_seconds_count{instance=~"$instance",job=~"$job",slice="inner_eval"}[5m]
+                                    )
+                                seriesNameFormat: '{{job}} - {{instance}} - Query Rate'
+        "4_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Stage Duration
+                    description: Shows duration of different Prometheus query stages
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                        yAxis:
+                            format:
+                                unit: seconds
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    max by (slice) (
+                                      prometheus_engine_query_duration_seconds{instance=~"$instance",job=~"$job",quantile="0.9"}
+                                    )
+                                seriesNameFormat: '{{slice}} - Duration'
+    layouts:
+        - kind: Grid
+          spec:
+            display:
+                title: Prometheus Stats
+            items:
+                - x: 0
+                  "y": 0
+                  width: 24
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_0'
+        - kind: Grid
+          spec:
+            display:
+                title: Discovery
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Retrieval
+            items:
+                - x: 0
+                  "y": 0
+                  width: 8
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_0'
+                - x: 8
+                  "y": 0
+                  width: 8
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_1'
+                - x: 16
+                  "y": 0
+                  width: 8
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_2'
+        - kind: Grid
+          spec:
+            display:
+                title: Storage
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Query
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/4_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/4_1'
+    duration: 1h

--- a/examples/dashboards/perses/prometheus-remote-write.yaml
+++ b/examples/dashboards/perses/prometheus-remote-write.yaml
@@ -1,0 +1,555 @@
+kind: Dashboard
+metadata:
+    name: prometheus-remote-write
+    createdAt: 0001-01-01T00:00:00Z
+    updatedAt: 0001-01-01T00:00:00Z
+    version: 0
+    project: perses-dev
+spec:
+    display:
+        name: Prometheus / Remote Write
+    variables:
+        - kind: ListVariable
+          spec:
+            display:
+                name: instance
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: instance
+                    matchers:
+                        - prometheus_remote_storage_shards{}
+            name: instance
+        - kind: ListVariable
+          spec:
+            display:
+                name: url
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: url
+                    matchers:
+                        - prometheus_remote_storage_shards{instance="$instance"}
+            name: url
+    panels:
+        "0_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Timestamp Lag
+                    description: Shows timestamp lag in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    (
+                                        prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}
+                                      - ignoring (remote_name, url) group_right (instance)
+                                        (
+                                            prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}
+                                          !=
+                                            0
+                                        )
+                                    )
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Segment'
+        "0_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Rate[5m]
+                    description: Shows rate metrics over 5 minute intervals
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    clamp_min(
+                                        rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}[5m])
+                                      - ignoring (remote_name, url) group_right (instance)
+                                        rate(
+                                          prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}[5m]
+                                        ),
+                                      0
+                                    )
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "1_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Rate, in vs. succeeded or dropped [5m]
+                    description: Shows rate of samples in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                        rate(prometheus_remote_storage_samples_in_total{instance=~"$instance"}[5m])
+                                      - ignoring (remote_name, url) group_right (instance)
+                                        (
+                                            rate(prometheus_remote_storage_succeeded_samples_total{instance=~"$instance",url="$url"}[5m])
+                                          or
+                                            rate(prometheus_remote_storage_samples_total{instance=~"$instance",url="$url"}[5m])
+                                        )
+                                    -
+                                      (
+                                          rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                                        or
+                                          rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                                      )
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "2_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Current Shards
+                    description: Shows current number of shards in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_remote_storage_shards{instance=~"$instance",url="$url"}
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "2_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Desired Shards
+                    description: Shows desired number of shards in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_remote_storage_shards_desired{instance=~"$instance",url="$url"}
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "2_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Max Shards
+                    description: Shows maximum number of shards in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_remote_storage_shards_max{instance=~"$instance",url="$url"}
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "2_3":
+            kind: Panel
+            spec:
+                display:
+                    name: Min Shards
+                    description: Shows minimum number of shards in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_remote_storage_shards_min{instance=~"$instance",url="$url"}
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "3_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Shard Capacity
+                    description: Shows shard capacity in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_remote_storage_shard_capacity{instance=~"$instance",url="$url"}
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "3_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Pending Samples
+                    description: Shows number of pending samples in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      prometheus_remote_storage_pending_samples{instance=~"$instance",url="$url"}
+                                    or
+                                      prometheus_remote_storage_samples_pending{instance=~"$instance",url="$url"}
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "4_0":
+            kind: Panel
+            spec:
+                display:
+                    name: TSDB Current Segment
+                    description: Shows current TSDB WAL segment
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_tsdb_wal_segment_current{instance=~"$instance"}
+                                seriesNameFormat: '{{instance}} - Segment - Metrics'
+        "4_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Remote Write Current Segment
+                    description: Shows current remote write WAL segment
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: prometheus_wal_watcher_current_segment{instance=~"$instance"}
+                                seriesNameFormat: '{{instance}} - Segment - Metrics'
+        "5_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Dropped Samples Rate
+                    description: Shows rate of dropped samples in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                                    or
+                                      rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "5_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Failed Samples
+                    description: Shows rate of failed samples in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      rate(prometheus_remote_storage_failed_samples_total{instance=~"$instance",url="$url"}[5m])
+                                    or
+                                      rate(prometheus_remote_storage_samples_failed_total{instance=~"$instance",url="$url"}[5m])
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "5_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Retried Samples
+                    description: Shows rate of retried samples in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      rate(prometheus_remote_storage_retried_samples_total{instance=~"$instance",url=~"$url"}[5m])
+                                    or
+                                      rate(prometheus_remote_storage_samples_retried_total{instance=~"$instance",url=~"$url"}[5m])
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+        "5_3":
+            kind: Panel
+            spec:
+                display:
+                    name: Enqueue Retries
+                    description: Shows rate of enqueue retries in remote storage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(prometheus_remote_storage_enqueue_retries_total{instance=~"$instance",url=~"$url"}[5m])
+                                seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
+    layouts:
+        - kind: Grid
+          spec:
+            display:
+                title: Timestamps
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/0_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Samples
+            items:
+                - x: 0
+                  "y": 0
+                  width: 24
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/1_0'
+        - kind: Grid
+          spec:
+            display:
+                title: Shards
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_1'
+                - x: 0
+                  "y": 6
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_2'
+                - x: 12
+                  "y": 6
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/2_3'
+        - kind: Grid
+          spec:
+            display:
+                title: Shard Details
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/3_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Segments
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/4_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/4_1'
+        - kind: Grid
+          spec:
+            display:
+                title: Misc. Rates
+            items:
+                - x: 0
+                  "y": 0
+                  width: 6
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/5_0'
+                - x: 6
+                  "y": 0
+                  width: 6
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/5_1'
+                - x: 12
+                  "y": 0
+                  width: 6
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/5_2'
+                - x: 18
+                  "y": 0
+                  width: 6
+                  height: 6
+                  content:
+                    $ref: '#/spec/panels/5_3'
+    duration: 1h


### PR DESCRIPTION
This commit modifies Makefile to add generated dashboard YAML (both operator CRD and regular config) to examples dir.

Provides easy way for downstream user to just get YAML without cloning. Also, makes it easier to view dashboard diffs for future changes.