### PR TITLE
Add exec, dashboardWriter methods for getting runtime.Objects

### DIFF
--- a/pkg/dashboards/dashboard_writer.go
+++ b/pkg/dashboards/dashboard_writer.go
@@ -1,6 +1,9 @@
 package dashboards
 
-import "github.com/perses/perses/go-sdk/dashboard"
+import (
+	"github.com/perses/perses/go-sdk/dashboard"
+	"k8s.io/apimachinery/pkg/runtime"
+)
 
 type DashboardWriter struct {
 	dashboardResults []DashboardResult
@@ -18,6 +21,7 @@ func NewDashboardWriter() *DashboardWriter {
 	}
 }
 
+// Add adds a dashboard to the writer.
 func (w *DashboardWriter) Add(builder dashboard.Builder, err error) {
 	w.dashboardResults = append(w.dashboardResults, DashboardResult{
 		builder: builder,
@@ -25,8 +29,18 @@ func (w *DashboardWriter) Add(builder dashboard.Builder, err error) {
 	})
 }
 
+// Write writes the dashboards to the output directory.
 func (w *DashboardWriter) Write() {
 	for _, result := range w.dashboardResults {
 		w.executor.BuildDashboard(result.builder, result.err)
 	}
+}
+
+// OperatorResources returns the operator resources of the dashboards added to the writer.
+func (w *DashboardWriter) OperatorResources() []runtime.Object {
+	operatorResources := []runtime.Object{}
+	for _, result := range w.dashboardResults {
+		operatorResources = append(operatorResources, w.executor.BuildDashboardOperatorResource(result.builder))
+	}
+	return operatorResources
 }


### PR DESCRIPTION
This commit adds helper methods to exec and dashboardWriter to allow getting PersesDashboard structs (as runtime.Objects) directly instead of writing to file.

This is particularly useful when building controllers that deploy PersesDashboards.