### PR TITLE
[CHORE] aligning output dir with percli dac build cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,7 +150,7 @@ $RECYCLE.BIN/
 # End of https://www.toptal.com/developers/gitignore/api/go,visualstudiocode,vim,linux,macos,windows,git
 
 # dashboard build directory
-dist/
+built/
 
 # tmp folder
 tmp/

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ GOOS?=$(shell go env GOOS)
 ENVVARS=GOOS=$(GOOS) CGO_ENABLED=0
 
 # Dashboard build configuration with defaults
-OUTPUT_DIR_OPERATOR ?= ./dist/dashboards/operator
-OUTPUT_DIR_PERSES ?= ./dist/dashboards/perses
+OUTPUT_DIR_OPERATOR ?= ./built/dashboards/operator
+OUTPUT_DIR_PERSES ?= ./built/dashboards/perses
 OUTPUT_FORMAT_PERSES ?= json
 PROJECT ?= default
 DATASOURCE ?= prometheus-datasource

--- a/pkg/dashboards/exec.go
+++ b/pkg/dashboards/exec.go
@@ -23,7 +23,7 @@ const (
 
 func init() {
 	flag.String("output", YAMLOutput, "output format of the exec")
-	flag.String("output-dir", "./dist", "output directory of the exec")
+	flag.String("output-dir", "./built", "output directory of the exec")
 }
 
 func executeDashboardBuilder(builder dashboard.Builder, outputFormat string, outputDir string, errWriter io.Writer) {


### PR DESCRIPTION
This pull request updates the output directory paths for dashboard builds to align with a new directory structure. The changes affect both the `Makefile` and the `pkg/dashboards/exec.go` file.

### Updates to output directory paths:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L20-R21): Changed the `OUTPUT_DIR_OPERATOR` and `OUTPUT_DIR_PERSES` default paths from `./dist/dashboards/...` to `./built/dashboards/...` to reflect the new directory structure.
* [`pkg/dashboards/exec.go`](diffhunk://#diff-370ccb5720a3898eaf957f9613990a48911b3e25752e161d90d93171e0f9c6e5L26-R26): Updated the `output-dir` flag's default value from `./dist` to `./built` to ensure consistency with the updated directory structure.