### PR TITLE
Allow variables in queries

### DIFF
--- a/examples/dashboards/operator/alertmanager-overview.yaml
+++ b/examples/dashboards/operator/alertmanager-overview.yaml
@@ -97,7 +97,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: sum by (job, instance) (rate(alertmanager_alerts_received_total{job=~"$job"}[5m]))
+                query: sum by (job, instance) (rate(alertmanager_alerts_received_total{job=~"$job"}[$__rate_interval]))
                 seriesNameFormat: '{{instance}} - Alertmanager - Received'
         - kind: TimeSeriesQuery
           spec:
@@ -107,7 +107,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: sum by (job, instance) (rate(alertmanager_alerts_invalid_total{job=~"$job"}[5m]))
+                query: sum by (job, instance) (rate(alertmanager_alerts_invalid_total{job=~"$job"}[$__rate_interval]))
                 seriesNameFormat: '{{instance}} - Alertmanager - Invalid'
     "1_0":
       kind: Panel
@@ -134,7 +134,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (integration, instance) (
-                    rate(alertmanager_notifications_total{integration=~"$integration",job=~"$job"}[5m])
+                    rate(alertmanager_notifications_total{integration=~"$integration",job=~"$job"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{instance}} - {{integration}} - Total'
         - kind: TimeSeriesQuery
@@ -147,7 +147,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (integration, instance) (
-                    rate(alertmanager_notifications_failed_total{integration=~"$integration",job=~"$job"}[5m])
+                    rate(alertmanager_notifications_failed_total{integration=~"$integration",job=~"$job"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{instance}} - {{integration}} - Failed'
     "1_1":
@@ -180,7 +180,9 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (le, integration, instance) (
-                      rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                      rate(
+                        alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: '{{instance}} - {{integration}} - 99th Percentile'
@@ -196,7 +198,9 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (le, integration, instance) (
-                      rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                      rate(
+                        alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: '{{instance}} - {{integration}} - Median'
@@ -210,11 +214,15 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (integration, instance) (
-                      rate(alertmanager_notification_latency_seconds_sum{integration=~"$integration",job=~"$job"}[5m])
+                      rate(
+                        alertmanager_notification_latency_seconds_sum{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                      )
                     )
                   /
                     sum by (integration, instance) (
-                      rate(alertmanager_notification_latency_seconds_count{integration=~"$integration",job=~"$job"}[5m])
+                      rate(
+                        alertmanager_notification_latency_seconds_count{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                      )
                     )
                 seriesNameFormat: '{{instance}} - {{integration}} - Average'
   variables:

--- a/examples/dashboards/operator/kubernetes-cluster-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes-cluster-resources-overview.yaml
@@ -717,44 +717,8 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace) (
-                    rate(container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
-                  )
-        - kind: TimeSeriesQuery
-          spec:
-            plugin:
-              kind: PrometheusTimeSeriesQuery
-              spec:
-                datasource:
-                  kind: PrometheusDatasource
-                  name: prometheus-datasource
-                query: |-
-                  sum by (namespace) (
-                    rate(container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
-                  )
-        - kind: TimeSeriesQuery
-          spec:
-            plugin:
-              kind: PrometheusTimeSeriesQuery
-              spec:
-                datasource:
-                  kind: PrometheusDatasource
-                  name: prometheus-datasource
-                query: |-
-                  sum by (namespace) (
-                    rate(container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
-                  )
-        - kind: TimeSeriesQuery
-          spec:
-            plugin:
-              kind: PrometheusTimeSeriesQuery
-              spec:
-                datasource:
-                  kind: PrometheusDatasource
-                  name: prometheus-datasource
-                query: |-
-                  sum by (namespace) (
                     rate(
-                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                      container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -768,7 +732,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     rate(
-                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                      container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -782,7 +746,49 @@ spec:
                 query: |-
                   sum by (namespace) (
                     rate(
-                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                      container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                    )
+                  )
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (namespace) (
+                    rate(
+                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                    )
+                  )
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (namespace) (
+                    rate(
+                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                    )
+                  )
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (namespace) (
+                    rate(
+                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                     )
                   )
     "6_0":
@@ -818,7 +824,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace) (
-                    rate(container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                    rate(
+                      container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}}'
     "6_1":
@@ -854,7 +862,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace) (
-                    rate(container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                    rate(
+                      container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}}'
     "7_0":
@@ -891,7 +901,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   avg by (namespace) (
-                    irate(container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                    irate(
+                      container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}}'
     "7_1":
@@ -928,7 +940,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   avg by (namespace) (
-                    irate(container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                    irate(
+                      container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}}'
     "8_0":
@@ -965,7 +979,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     irate(
-                      container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                      container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}}'
@@ -1003,7 +1017,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     irate(
-                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}}'
@@ -1041,7 +1055,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     irate(
-                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}}'
@@ -1079,7 +1093,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     irate(
-                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}}'
@@ -1118,10 +1132,12 @@ spec:
                   ceil(
                     sum by (namespace) (
                         rate(
-                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                         )
                       +
-                        rate(container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[5m])
+                        rate(
+                          container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[$__rate_interval]
+                        )
                     )
                   )
                 seriesNameFormat: '{{namespace}}'
@@ -1159,11 +1175,11 @@ spec:
                 query: |-
                   sum by (namespace) (
                       rate(
-                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[5m]
+                        container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[$__rate_interval]
                       )
                   )
                 seriesNameFormat: '{{namespace}}'
@@ -1216,7 +1232,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     rate(
-                      container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                      container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1230,7 +1246,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     rate(
-                      container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                      container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1244,11 +1260,11 @@ spec:
                 query: |-
                   sum by (namespace) (
                       rate(
-                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                       )
                   )
         - kind: TimeSeriesQuery
@@ -1262,7 +1278,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     rate(
-                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1276,7 +1292,7 @@ spec:
                 query: |-
                   sum by (namespace) (
                     rate(
-                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1290,11 +1306,11 @@ spec:
                 query: |-
                   sum by (namespace) (
                       rate(
-                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                       )
                   )
   variables:

--- a/examples/dashboards/operator/kubernetes-namespace-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes-namespace-resources-overview.yaml
@@ -735,7 +735,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                      container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -749,7 +749,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                      container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -763,7 +763,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                      container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -777,7 +777,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -791,7 +791,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -805,7 +805,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
     "6_0":
@@ -841,7 +841,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (pod) (
-                    rate(container_network_receive_bytes_total{cluster="$cluster",namespace="$namespace"}[5m])
+                    rate(container_network_receive_bytes_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{pod}}'
     "6_1":
@@ -877,7 +877,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (pod) (
-                    rate(container_network_transmit_bytes_total{cluster="$cluster",namespace="$namespace"}[5m])
+                    rate(container_network_transmit_bytes_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{pod}}'
     "7_0":
@@ -913,7 +913,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (pod) (
-                    irate(container_network_receive_packets_total{cluster="$cluster",namespace="$namespace"}[5m])
+                    irate(container_network_receive_packets_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{pod}}'
     "7_1":
@@ -949,7 +949,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (pod) (
-                    irate(container_network_transmit_packets_total{cluster="$cluster",namespace="$namespace"}[5m])
+                    irate(
+                      container_network_transmit_packets_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{pod}}'
     "8_0":
@@ -986,7 +988,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     irate(
-                      container_network_receive_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[5m]
+                      container_network_receive_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -1025,7 +1027,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     irate(
-                      container_network_transmit_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[5m]
+                      container_network_transmit_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -1064,11 +1066,11 @@ spec:
                   ceil(
                     sum by (pod) (
                         rate(
-                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                         )
                       +
                         rate(
-                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                         )
                     )
                   )
@@ -1107,11 +1109,11 @@ spec:
                 query: |-
                   sum by (pod) (
                       rate(
-                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                       )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -1164,7 +1166,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                      container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1178,7 +1180,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                      container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1192,11 +1194,11 @@ spec:
                 query: |-
                   sum by (pod) (
                       rate(
-                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                       )
                   )
         - kind: TimeSeriesQuery
@@ -1210,7 +1212,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1224,7 +1226,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1238,11 +1240,11 @@ spec:
                 query: |-
                   sum by (pod) (
                       rate(
-                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                       )
                   )
   variables:

--- a/examples/dashboards/operator/kubernetes-pod-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes-pod-resources-overview.yaml
@@ -263,13 +263,13 @@ spec:
                 query: |2-
                     sum by (container) (
                       increase(
-                        container_cpu_cfs_throttled_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_cpu_cfs_throttled_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                     )
                   /
                     sum by (container) (
                       increase(
-                        container_cpu_cfs_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_cpu_cfs_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{container}}'
@@ -621,7 +621,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     irate(
-                      container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -659,7 +659,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -697,7 +697,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -735,7 +735,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -773,7 +773,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -811,7 +811,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{pod}}'
@@ -850,7 +850,7 @@ spec:
                   ceil(
                     sum by (pod) (
                       rate(
-                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                       )
                     )
                   )
@@ -867,7 +867,7 @@ spec:
                   ceil(
                     sum by (pod) (
                       rate(
-                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                       )
                     )
                   )
@@ -906,7 +906,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: Writes
@@ -921,7 +921,7 @@ spec:
                 query: |-
                   sum by (pod) (
                     rate(
-                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: Reads
@@ -960,11 +960,11 @@ spec:
                   ceil(
                     sum by (container) (
                         rate(
-                          container_fs_reads_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                          container_fs_reads_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                         )
                       +
                         rate(
-                          container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                          container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                         )
                     )
                   )
@@ -1003,11 +1003,11 @@ spec:
                 query: |-
                   sum by (container) (
                       rate(
-                        container_fs_reads_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_fs_reads_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                   )
                 seriesNameFormat: '{{container}}'
@@ -1060,7 +1060,7 @@ spec:
                 query: |-
                   sum by (container) (
                     rate(
-                      container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                      container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1074,7 +1074,7 @@ spec:
                 query: |-
                   sum by (container) (
                     rate(
-                      container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                      container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1088,11 +1088,11 @@ spec:
                 query: |-
                   sum by (container) (
                       rate(
-                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                   )
         - kind: TimeSeriesQuery
@@ -1106,7 +1106,7 @@ spec:
                 query: |-
                   sum by (container) (
                     rate(
-                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                      container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1120,7 +1120,7 @@ spec:
                 query: |-
                   sum by (container) (
                     rate(
-                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                      container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                     )
                   )
         - kind: TimeSeriesQuery
@@ -1134,11 +1134,11 @@ spec:
                 query: |-
                   sum by (container) (
                       rate(
-                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                     +
                       rate(
-                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                       )
                   )
   variables:

--- a/examples/dashboards/operator/kubernetes-workload-ns-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes-workload-ns-resources-overview.yaml
@@ -593,7 +593,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -611,7 +611,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -629,7 +629,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -647,7 +647,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -665,7 +665,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -683,7 +683,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -724,7 +724,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -766,7 +766,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -809,7 +809,7 @@ spec:
                   (
                     avg by (workload) (
                         rate(
-                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -852,7 +852,7 @@ spec:
                   (
                     avg by (workload) (
                         rate(
-                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -895,7 +895,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -938,7 +938,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -981,7 +981,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -1024,7 +1024,7 @@ spec:
                   (
                     sum by (workload) (
                         rate(
-                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}

--- a/examples/dashboards/operator/kubernetes-workload-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes-workload-resources-overview.yaml
@@ -499,7 +499,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -517,7 +517,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -535,7 +535,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -553,7 +553,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -571,7 +571,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -589,7 +589,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -630,7 +630,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -672,7 +672,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -715,7 +715,7 @@ spec:
                   (
                     avg by (pod) (
                         rate(
-                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -758,7 +758,7 @@ spec:
                   (
                     avg by (pod) (
                         rate(
-                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -800,7 +800,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -842,7 +842,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -884,7 +884,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -927,7 +927,7 @@ spec:
                   (
                     sum by (pod) (
                         rate(
-                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                          container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                         )
                       * on (namespace, pod) group_left (workload, workload_type)
                         namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}

--- a/examples/dashboards/operator/node-exporter-nodes.yaml
+++ b/examples/dashboards/operator/node-exporter-nodes.yaml
@@ -115,7 +115,7 @@ spec:
                           1
                         -
                           sum without (mode) (
-                            rate(node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[5m])
+                            rate(node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval])
                           )
                       )
                     / ignoring (cpu) group_left ()
@@ -292,7 +292,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[5m])
+                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - Usage'
         - kind: TimeSeriesQuery
           spec:
@@ -302,7 +302,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - Written'
     "2_1":
       kind: Panel
@@ -330,7 +330,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - IO Time'
     "3_0":
       kind: Panel
@@ -358,7 +358,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                query: rate(node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Network - Received'
     "3_1":
       kind: Panel
@@ -386,7 +386,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_network_transmit_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                query: rate(node_network_transmit_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Network - Transmitted'
   variables:
   - kind: ListVariable

--- a/examples/dashboards/operator/perses-overview.yaml
+++ b/examples/dashboards/operator/perses-overview.yaml
@@ -157,11 +157,11 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (handler, method) (
-                      rate(perses_http_request_duration_second_sum{instance=~"$instance",job=~"$job"}[5m])
+                      rate(perses_http_request_duration_second_sum{instance=~"$instance",job=~"$job"}[$__rate_interval])
                     )
                   /
                     sum by (handler, method) (
-                      rate(perses_http_request_duration_second_count{instance=~"$instance",job=~"$job"}[5m])
+                      rate(perses_http_request_duration_second_count{instance=~"$instance",job=~"$job"}[$__rate_interval])
                     )
                 seriesNameFormat: '{{handler}} {{method}}'
     "1_1":
@@ -188,7 +188,10 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: sum by (handler, code) (rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[5m]))
+                query: |-
+                  sum by (handler, code) (
+                    rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
+                  )
                 seriesNameFormat: '{{handler}} {{method}} {{code}}'
     "1_2":
       kind: Panel
@@ -216,7 +219,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (handler, code) (
-                    rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[5m])
+                    rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{handler}} {{method}} {{code}}'
     "2_0":
@@ -339,7 +342,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(process_cpu_seconds_total{instance=~"$instance",job=~"$job"}[5m])
+                query: rate(process_cpu_seconds_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
                 seriesNameFormat: '{{pod}}'
     "2_2":
       kind: Panel

--- a/examples/dashboards/operator/perses-overview.yaml
+++ b/examples/dashboards/operator/perses-overview.yaml
@@ -274,7 +274,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_alloc_bytes_total{instance=~"$instance",job=~"$job"}[5m])
+                query: rate(go_memstats_alloc_bytes_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate All {{pod}}
         - kind: TimeSeriesQuery
           spec:
@@ -284,7 +284,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_heap_alloc_bytes{instance=~"$instance",job=~"$job"}[5m])
+                query: rate(go_memstats_heap_alloc_bytes{instance=~"$instance",job=~"$job"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate Heap {{pod}}
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/prometheus-overview.yaml
+++ b/examples/dashboards/operator/prometheus-overview.yaml
@@ -155,7 +155,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (job, scrape_job, instance) (
-                    rate(prometheus_target_sync_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                    rate(prometheus_target_sync_length_seconds_sum{instance=~"$instance",job=~"$job"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} - {{instance}} - Metrics'
     "1_1":
@@ -206,9 +206,9 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: |2-
-                    rate(prometheus_target_interval_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                    rate(prometheus_target_interval_length_seconds_sum{instance=~"$instance",job=~"$job"}[$__rate_interval])
                   /
-                    rate(prometheus_target_interval_length_seconds_count{instance=~"$instance",job=~"$job"}[5m])
+                    rate(prometheus_target_interval_length_seconds_count{instance=~"$instance",job=~"$job"}[$__rate_interval])
                 seriesNameFormat: '{{job}} - {{instance}} - {{interval}} Configured'
     "2_1":
       kind: Panel
@@ -234,7 +234,7 @@ spec:
                 query: |-
                   sum by (job, instance) (
                     rate(
-                      prometheus_target_scrapes_exceeded_body_size_limit_total{instance=~"$instance",job=~"$job"}[1m]
+                      prometheus_target_scrapes_exceeded_body_size_limit_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: 'exceeded body size limit: {{job}} - {{instance}}
@@ -249,7 +249,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (job, instance) (
-                    rate(prometheus_target_scrapes_exceeded_sample_limit_total{instance=~"$instance",job=~"$job"}[1m])
+                    rate(
+                      prometheus_target_scrapes_exceeded_sample_limit_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: 'exceeded sample limit: {{job}} - {{instance}} -
                   Metrics'
@@ -264,7 +266,7 @@ spec:
                 query: |-
                   sum by (job, instance) (
                     rate(
-                      prometheus_target_scrapes_sample_duplicate_timestamp_total{instance=~"$instance",job=~"$job"}[1m]
+                      prometheus_target_scrapes_sample_duplicate_timestamp_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: 'duplicate timestamp: {{job}} - {{instance}} - Metrics'
@@ -278,7 +280,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (job, instance) (
-                    rate(prometheus_target_scrapes_sample_out_of_bounds_total{instance=~"$instance",job=~"$job"}[1m])
+                    rate(
+                      prometheus_target_scrapes_sample_out_of_bounds_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: 'out of bounds: {{job}} - {{instance}} - Metrics'
         - kind: TimeSeriesQuery
@@ -291,7 +295,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (job, instance) (
-                    rate(prometheus_target_scrapes_sample_out_of_order_total{instance=~"$instance",job=~"$job"}[1m])
+                    rate(
+                      prometheus_target_scrapes_sample_out_of_order_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: 'out of order: {{job}} - {{instance}} - Metrics'
     "2_2":
@@ -315,7 +321,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(prometheus_tsdb_head_samples_appended_total{instance=~"$instance",job=~"$job"}[5m])
+                query: rate(prometheus_tsdb_head_samples_appended_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
                 seriesNameFormat: '{{job}} - {{instance}} - {{remote_name}} - {{url}}'
     "3_0":
       kind: Panel
@@ -386,7 +392,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   rate(
-                    prometheus_engine_query_duration_seconds_count{instance=~"$instance",job=~"$job",slice="inner_eval"}[5m]
+                    prometheus_engine_query_duration_seconds_count{instance=~"$instance",job=~"$job",slice="inner_eval"}[$__rate_interval]
                   )
                 seriesNameFormat: '{{job}} - {{instance}} - Query Rate'
     "4_1":

--- a/examples/dashboards/operator/prometheus-remote-write.yaml
+++ b/examples/dashboards/operator/prometheus-remote-write.yaml
@@ -172,7 +172,7 @@ spec:
       spec:
         display:
           description: Shows rate metrics over 5 minute intervals
-          name: Rate[5m]
+          name: Rate
         plugin:
           kind: TimeSeriesChart
           spec:
@@ -190,10 +190,10 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   clamp_min(
-                      rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}[5m])
+                      rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}[$__rate_interval])
                     - ignoring (remote_name, url) group_right (instance)
                       rate(
-                        prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}[5m]
+                        prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}[$__rate_interval]
                       ),
                     0
                   )
@@ -203,7 +203,7 @@ spec:
       spec:
         display:
           description: Shows rate of samples in remote storage
-          name: Rate, in vs. succeeded or dropped [5m]
+          name: Rate, in vs. succeeded or dropped
         plugin:
           kind: TimeSeriesChart
           spec:
@@ -220,18 +220,18 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: |2-
-                      rate(prometheus_remote_storage_samples_in_total{instance=~"$instance"}[5m])
+                      rate(prometheus_remote_storage_samples_in_total{instance=~"$instance"}[$__rate_interval])
                     - ignoring (remote_name, url) group_right (instance)
                       (
-                          rate(prometheus_remote_storage_succeeded_samples_total{instance=~"$instance",url="$url"}[5m])
+                          rate(prometheus_remote_storage_succeeded_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                         or
-                          rate(prometheus_remote_storage_samples_total{instance=~"$instance",url="$url"}[5m])
+                          rate(prometheus_remote_storage_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                       )
                   -
                     (
-                        rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                        rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                       or
-                        rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                        rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[$__rate_interval])
                     )
                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
     "2_0":
@@ -443,9 +443,9 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: |2-
-                    rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                    rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                   or
-                    rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                    rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[$__rate_interval])
                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
     "5_1":
       kind: Panel
@@ -469,9 +469,9 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: |2-
-                    rate(prometheus_remote_storage_failed_samples_total{instance=~"$instance",url="$url"}[5m])
+                    rate(prometheus_remote_storage_failed_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                   or
-                    rate(prometheus_remote_storage_samples_failed_total{instance=~"$instance",url="$url"}[5m])
+                    rate(prometheus_remote_storage_samples_failed_total{instance=~"$instance",url="$url"}[$__rate_interval])
                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
     "5_2":
       kind: Panel
@@ -495,9 +495,9 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: |2-
-                    rate(prometheus_remote_storage_retried_samples_total{instance=~"$instance",url=~"$url"}[5m])
+                    rate(prometheus_remote_storage_retried_samples_total{instance=~"$instance",url=~"$url"}[$__rate_interval])
                   or
-                    rate(prometheus_remote_storage_samples_retried_total{instance=~"$instance",url=~"$url"}[5m])
+                    rate(prometheus_remote_storage_samples_retried_total{instance=~"$instance",url=~"$url"}[$__rate_interval])
                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
     "5_3":
       kind: Panel
@@ -520,7 +520,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(prometheus_remote_storage_enqueue_retries_total{instance=~"$instance",url=~"$url"}[5m])
+                query: rate(prometheus_remote_storage_enqueue_retries_total{instance=~"$instance",url=~"$url"}[$__rate_interval])
                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
   variables:
   - kind: ListVariable

--- a/examples/dashboards/operator/thanos-compact-overview.yaml
+++ b/examples/dashboards/operator/thanos-compact-overview.yaml
@@ -341,7 +341,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, resolution) (
-                    rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: 'Resolution: {{resolution}} - {{job}} {{namespace}}'
     "1_1":
@@ -372,11 +372,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job) (
-                          rate(thanos_compact_group_compactions_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_compact_group_compactions_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       /
                         sum by (namespace, job) (
-                          rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -409,7 +409,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, resolution) (
-                    rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: 'Resolution: {{resolution}} - {{job}} {{namespace}}'
     "2_1":
@@ -440,11 +440,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job) (
-                          rate(thanos_compact_downsample_failed_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_compact_downsample_failed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       /
                         sum by (namespace, job) (
-                          rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -479,7 +479,9 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, resolution, le) (
-                      rate(thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: 'p50 Resolution: {{resolution}} - {{job}} {{namespace}}'
@@ -495,7 +497,9 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, resolution, le) (
-                      rate(thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: 'p90 Resolution: {{resolution}} - {{job}} {{namespace}}'
@@ -511,7 +515,9 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, resolution, le) (
-                      rate(thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: 'p99 Resolution: {{resolution}} - {{job}} {{namespace}}'
@@ -541,7 +547,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "3_1":
@@ -572,11 +578,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job) (
-                          rate(thanos_blocks_meta_sync_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_blocks_meta_sync_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       /
                         sum by (namespace, job) (
-                          rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -611,7 +617,7 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, le) (
-                      rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -627,7 +633,7 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, le) (
-                      rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -643,7 +649,7 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, le) (
-                      rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -673,7 +679,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_compact_blocks_cleaned_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_compact_blocks_cleaned_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "4_1":
@@ -703,7 +709,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_compact_block_cleanup_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_compact_block_cleanup_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "4_2":
@@ -734,7 +740,7 @@ spec:
                 query: |-
                   sum by (namespace, job) (
                     rate(
-                      thanos_compact_blocks_marked_total{job=~"$job",marker="deletion-mark.json",namespace="$namespace"}[5m]
+                      thanos_compact_blocks_marked_total{job=~"$job",marker="deletion-mark.json",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
@@ -765,7 +771,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, operation) (
-                    rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{operation}} {{namespace}}'
     "5_1":
@@ -796,11 +802,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job, operation) (
-                          rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       /
                         sum by (namespace, job, operation) (
-                          rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -835,7 +841,7 @@ spec:
                     0.99,
                     sum by (namespace, job, operation, le) (
                       rate(
-                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -853,7 +859,7 @@ spec:
                     0.9,
                     sum by (namespace, job, operation, le) (
                       rate(
-                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -871,7 +877,7 @@ spec:
                     0.5,
                     sum by (namespace, job, operation, le) (
                       rate(
-                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -929,7 +935,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "7_1":
@@ -960,11 +966,13 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job) (
-                          rate(thanos_compact_garbage_collection_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(
+                            thanos_compact_garbage_collection_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                          )
                         )
                       /
                         sum by (namespace, job) (
-                          rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -1000,7 +1008,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1018,7 +1026,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1036,7 +1044,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )

--- a/examples/dashboards/operator/thanos-compact-overview.yaml
+++ b/examples/dashboards/operator/thanos-compact-overview.yaml
@@ -1101,7 +1101,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate All {{pod}}
         - kind: TimeSeriesQuery
           spec:
@@ -1111,7 +1111,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate Heap {{pod}}
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/operator/thanos-query-frontend-overview.yaml
@@ -431,7 +431,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate All {{pod}}
         - kind: TimeSeriesQuery
           spec:
@@ -441,7 +441,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate Heap {{pod}}
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/operator/thanos-query-frontend-overview.yaml
@@ -122,7 +122,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, handler, code) (
-                    rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m])
+                    rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{code}} - {{job}} {{namespace}}'
     "0_1":
@@ -151,7 +151,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, handler, code) (
-                    rate(thanos_query_frontend_queries_total{job=~"$job",namespace="$namespace",op="query_range"}[5m])
+                    rate(
+                      thanos_query_frontend_queries_total{job=~"$job",namespace="$namespace",op="query_range"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{code}} - {{job}} {{namespace}}'
     "0_2":
@@ -182,12 +184,12 @@ spec:
                 query: |2-
                     sum by (namespace, job, code) (
                       rate(
-                        http_requests_total{code=~"5..",handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                        http_requests_total{code=~"5..",handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (code) group_left ()
                     sum by (namespace, job) (
-                      rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m])
+                      rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                 seriesNameFormat: '{{code}} - {{job}} {{namespace}}'
     "0_3":
@@ -220,7 +222,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                        http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -238,7 +240,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                        http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -256,7 +258,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                        http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -287,7 +289,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, tripperware) (
-                    rate(cortex_cache_request_duration_seconds_count{job=~"$job",namespace="$namespace"}[5m])
+                    rate(cortex_cache_request_duration_seconds_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
     "1_1":
@@ -316,7 +318,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, tripperware) (
-                    rate(cortex_cache_hits_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(cortex_cache_hits_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
     "1_2":
@@ -345,7 +347,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, tripperware) (
-                    rate(querier_cache_misses_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(querier_cache_misses_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
     "1_3":
@@ -374,7 +376,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, tripperware) (
-                    rate(cortex_cache_fetched_keys_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(cortex_cache_fetched_keys_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
     "2_0":

--- a/examples/dashboards/operator/thanos-query-overview.yaml
+++ b/examples/dashboards/operator/thanos-query-overview.yaml
@@ -861,7 +861,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate All {{pod}}
         - kind: TimeSeriesQuery
           spec:
@@ -871,7 +871,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate Heap {{pod}}
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos-query-overview.yaml
+++ b/examples/dashboards/operator/thanos-query-overview.yaml
@@ -184,7 +184,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, handler, code) (
-                    rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                    rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}} {{handler}} {{code}}'
     "0_1":
@@ -215,11 +215,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job, code) (
-                          rate(http_requests_total{code=~"5..",handler="query",job=~"$job",namespace="$namespace"}[5m])
+                          rate(http_requests_total{code=~"5..",handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       / ignoring (code) group_left ()
                         sum by (namespace, job) (
-                          rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                          rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -253,7 +253,9 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, le) (
-                      rate(http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p50 {{job}} - {{namespace}} duration
@@ -269,7 +271,9 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, le) (
-                      rate(http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p90 {{job}} - {{namespace}} duration
@@ -285,7 +289,9 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, le) (
-                      rate(http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p99 {{job}} {{namespace}} duration
@@ -315,7 +321,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, handler, code) (
-                    rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[5m])
+                    rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}} {{handler}} {{code}}'
     "1_1":
@@ -346,11 +352,13 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job, code) (
-                          rate(http_requests_total{code=~"5..",handler="query_range",job=~"$job",namespace="$namespace"}[5m])
+                          rate(
+                            http_requests_total{code=~"5..",handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                          )
                         )
                       / ignoring (code) group_left ()
                         sum by (namespace, job) (
-                          rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[5m])
+                          rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -386,7 +394,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[5m]
+                        http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -404,7 +412,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[5m]
+                        http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -422,7 +430,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[5m]
+                        http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -454,7 +462,7 @@ spec:
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
                     rate(
-                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -485,13 +493,13 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
                       rate(
-                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -525,7 +533,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -543,7 +551,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -561,7 +569,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -593,7 +601,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
-                    rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                    rate(
+                      grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "3_1":
@@ -624,12 +634,14 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
-                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "3_2":
@@ -662,7 +674,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -680,7 +692,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -698,7 +710,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -726,10 +738,12 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: |2-
-                    max_over_time(thanos_query_concurrent_gate_queries_max{job=~"$job",namespace="$namespace"}[5m])
+                    max_over_time(
+                      thanos_query_concurrent_gate_queries_max{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                    )
                   -
                     avg_over_time(
-                      thanos_query_concurrent_gate_queries_in_flight{job=~"$job",namespace="$namespace"}[5m]
+                      thanos_query_concurrent_gate_queries_in_flight{job=~"$job",namespace="$namespace"}[$__rate_interval]
                     )
                 seriesNameFormat: '{{job}} {{pod}}'
     "5_0":
@@ -758,7 +772,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}}'
     "5_1":
@@ -788,11 +802,11 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job) (
-                      rate(thanos_query_store_apis_dns_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_query_store_apis_dns_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   /
                     sum by (namespace, job) (
-                      rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                 seriesNameFormat: '{{job}}'
     "6_0":

--- a/examples/dashboards/operator/thanos-receive-overview.yaml
+++ b/examples/dashboards/operator/thanos-receive-overview.yaml
@@ -299,7 +299,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, handler, code) (
-                    rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                    rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}} {{handler}} {{code}}'
     "0_1":
@@ -329,11 +329,13 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job, code) (
-                          rate(http_requests_total{code=~"5..",handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                          rate(
+                            http_requests_total{code=~"5..",handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                          )
                         )
                       / ignoring (code) group_left ()
                         sum by (namespace, job) (
-                          rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                          rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -367,7 +369,9 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, le) (
-                      rate(http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p50 {{job}} - {{namespace}} duration
@@ -383,7 +387,9 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, le) (
-                      rate(http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p90 {{job}} - {{namespace}} duration
@@ -399,7 +405,9 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, le) (
-                      rate(http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p99 {{job}} {{namespace}} duration
@@ -430,7 +438,7 @@ spec:
                 query: |-
                   sum by (tenant, job, handler, code) (
                     rate(
-                      http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                      http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{tenant}} {{code}} {{job}} {{namespace}} {{handler}}'
@@ -463,13 +471,13 @@ spec:
                     (
                         sum by (tenant, namespace, job, code) (
                           rate(
-                            http_requests_total{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                            http_requests_total{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                           )
                         )
                       / ignoring (code) group_left ()
                         sum by (tenant, namespace, job) (
                           rate(
-                            http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                            http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                           )
                         )
                     )
@@ -503,7 +511,7 @@ spec:
                 query: |2-
                     sum by (namespace, job, tenant) (
                       rate(
-                        http_request_duration_seconds_sum{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                        http_request_duration_seconds_sum{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                       )
                     )
                   /
@@ -538,13 +546,13 @@ spec:
                 query: |2-
                     sum by (namespace, job, tenant) (
                       rate(
-                        http_request_size_bytes_sum{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                        http_request_size_bytes_sum{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                       )
                     )
                   /
                     sum by (namespace, job, tenant) (
                       rate(
-                        http_request_size_bytes_count{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                        http_request_size_bytes_count{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{tenant}}'
@@ -575,13 +583,13 @@ spec:
                 query: |2-
                     sum by (namespace, job, tenant) (
                       rate(
-                        http_request_size_bytes_sum{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                        http_request_size_bytes_sum{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                       )
                     )
                   /
                     sum by (namespace, job, tenant) (
                       rate(
-                        http_request_size_bytes_count{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                        http_request_size_bytes_count{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{tenant}}'
@@ -638,7 +646,7 @@ spec:
                 query: |-
                   sum by (namespace, job, tenant) (
                     rate(
-                      thanos_receive_write_timeseries_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                      thanos_receive_write_timeseries_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{tenant}}'
@@ -667,7 +675,7 @@ spec:
                 query: |-
                   sum by (namespace, job, tenant) (
                     rate(
-                      thanos_receive_write_timeseries_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                      thanos_receive_write_timeseries_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{tenant}}'
@@ -695,7 +703,7 @@ spec:
                 query: |-
                   sum by (namespace, job, tenant) (
                     rate(
-                      thanos_receive_write_samples_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                      thanos_receive_write_samples_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{tenant}}'
@@ -723,7 +731,7 @@ spec:
                 query: |-
                   sum by (namespace, job, tenant) (
                     rate(
-                      thanos_receive_write_samples_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                      thanos_receive_write_samples_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{tenant}}'
@@ -753,7 +761,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_receive_replications_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_receive_replications_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}}'
     "4_1":
@@ -782,7 +790,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_receive_replications_total{job=~"$job",namespace="$namespace",result="error"}[5m])
+                    rate(
+                      thanos_receive_replications_total{job=~"$job",namespace="$namespace",result="error"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{job}}'
     "5_0":
@@ -811,7 +821,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}}'
     "5_1":
@@ -840,7 +850,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace",result="error"}[5m])
+                    rate(
+                      thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace",result="error"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{job}}'
     "6_0":
@@ -870,7 +882,7 @@ spec:
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
                     rate(
-                      grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                      grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -901,13 +913,13 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
                       rate(
-                        grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -941,7 +953,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -959,7 +971,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -977,7 +989,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1009,7 +1021,7 @@ spec:
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
                     rate(
-                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -1040,13 +1052,13 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
                       rate(
-                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -1080,7 +1092,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1098,7 +1110,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1116,7 +1128,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1148,7 +1160,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
-                    rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                    rate(
+                      grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "8_1":
@@ -1179,12 +1193,14 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
-                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "8_2":
@@ -1217,7 +1233,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1235,7 +1251,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1253,7 +1269,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1314,7 +1330,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(prometheus_tsdb_head_samples_appended_total{job=~"$job",namespace=~"$namespace"}[5m])
+                query: rate(prometheus_tsdb_head_samples_appended_total{job=~"$job",namespace=~"$namespace"}[$__rate_interval])
                 seriesNameFormat: '{{job}} - {{namespace}}'
     "10_1":
       kind: Panel

--- a/examples/dashboards/operator/thanos-receive-overview.yaml
+++ b/examples/dashboards/operator/thanos-receive-overview.yaml
@@ -1430,7 +1430,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate All {{pod}}
         - kind: TimeSeriesQuery
           spec:
@@ -1440,7 +1440,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate Heap {{pod}}
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos-ruler-overview.yaml
+++ b/examples/dashboards/operator/thanos-ruler-overview.yaml
@@ -870,7 +870,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate All {{pod}}
         - kind: TimeSeriesQuery
           spec:
@@ -880,7 +880,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate Heap {{pod}}
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos-ruler-overview.yaml
+++ b/examples/dashboards/operator/thanos-ruler-overview.yaml
@@ -191,7 +191,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, rule_group, strategy) (
-                    rate(prometheus_rule_evaluations_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(prometheus_rule_evaluations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{rule_group}} {{strategy}} - {{job}} {{namespace}}'
     "0_1":
@@ -220,7 +220,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, rule_group, strategy) (
-                    rate(prometheus_rule_evaluation_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(prometheus_rule_evaluation_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{rule_group}} {{strategy}} - {{job}} {{namespace}}'
     "0_2":
@@ -250,7 +250,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, rule_group, strategy) (
-                    rate(prometheus_rule_group_iterations_missed_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(prometheus_rule_group_iterations_missed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{rule_group}} {{strategy}} - {{job}} {{namespace}}'
     "0_3":
@@ -315,7 +315,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, alertmanager) (
-                    rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{alertmanager}} - {{job}} {{namespace}}'
     "1_1":
@@ -344,7 +344,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, alertmanager) (
-                    rate(thanos_alert_sender_alerts_dropped_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_alert_sender_alerts_dropped_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{alertmanager}} - {{job}} {{namespace}}'
     "1_2":
@@ -374,11 +374,11 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job) (
-                      rate(thanos_alert_sender_errors_total{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_alert_sender_errors_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   /
                     sum by (namespace, job) (
-                      rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "1_3":
@@ -410,7 +410,7 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, le) (
-                      rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -426,7 +426,7 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, le) (
-                      rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -442,7 +442,7 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, le) (
-                      rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -472,7 +472,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "2_1":
@@ -501,7 +501,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_alert_queue_alerts_popped_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_alert_queue_alerts_popped_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "2_2":
@@ -531,11 +531,11 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job) (
-                      rate(thanos_alert_queue_alerts_dropped_total{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_alert_queue_alerts_dropped_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   /
                     sum by (namespace, job) (
-                      rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "3_0":
@@ -565,7 +565,7 @@ spec:
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
                     rate(
-                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -596,13 +596,13 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
                       rate(
-                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -636,7 +636,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -654,7 +654,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -672,7 +672,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -704,7 +704,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
-                    rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                    rate(
+                      grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "4_1":
@@ -735,12 +737,14 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
-                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "4_2":
@@ -773,7 +777,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -791,7 +795,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -809,7 +813,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )

--- a/examples/dashboards/operator/thanos-store-overview.yaml
+++ b/examples/dashboards/operator/thanos-store-overview.yaml
@@ -255,7 +255,7 @@ spec:
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
                     rate(
-                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                      grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                     )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -286,13 +286,13 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
                       rate(
-                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -326,7 +326,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -344,7 +344,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -362,7 +362,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -394,7 +394,9 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, grpc_method, grpc_code) (
-                    rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                    rate(
+                      grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                    )
                   )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "1_1":
@@ -425,12 +427,14 @@ spec:
                 query: |2-
                     sum by (namespace, job, grpc_code) (
                       rate(
-                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   / ignoring (grpc_code) group_left ()
                     sum by (namespace, job) (
-                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
     "1_2":
@@ -463,7 +467,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -481,7 +485,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -499,7 +503,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                        grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -531,7 +535,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, operation) (
-                    rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{operation}} {{namespace}}'
     "2_1":
@@ -562,11 +566,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job, operation) (
-                          rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       /
                         sum by (namespace, job, operation) (
-                          rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -601,7 +605,7 @@ spec:
                     0.99,
                     sum by (namespace, job, operation, le) (
                       rate(
-                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -619,7 +623,7 @@ spec:
                     0.9,
                     sum by (namespace, job, operation, le) (
                       rate(
-                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -637,7 +641,7 @@ spec:
                     0.5,
                     sum by (namespace, job, operation, le) (
                       rate(
-                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -668,7 +672,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job) (
-                    rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{namespace}}'
     "3_1":
@@ -699,11 +703,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job) (
-                          rate(thanos_bucket_store_block_load_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_bucket_store_block_load_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       /
                         sum by (namespace, job) (
-                          rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -735,7 +739,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, operation) (
-                    rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{operation}} {{namespace}}'
     "3_3":
@@ -765,11 +769,11 @@ spec:
                 query: |2-
                     (
                         sum by (namespace, job) (
-                          rate(thanos_bucket_store_block_drop_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_bucket_store_block_drop_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                       /
                         sum by (namespace, job) (
-                          rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[5m])
+                          rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                         )
                     )
                   *
@@ -801,7 +805,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, item_type) (
-                    rate(thanos_store_index_cache_requests_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_store_index_cache_requests_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
     "4_1":
@@ -830,7 +834,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, item_type) (
-                    rate(thanos_store_index_cache_hits_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_store_index_cache_hits_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
     "4_2":
@@ -859,7 +863,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, item_type) (
-                    rate(thanos_store_index_cache_items_added_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_store_index_cache_items_added_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
     "4_3":
@@ -888,7 +892,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   sum by (namespace, job, item_type) (
-                    rate(thanos_store_index_cache_items_evicted_total{job=~"$job",namespace="$namespace"}[5m])
+                    rate(thanos_store_index_cache_items_evicted_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                   )
                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
     "5_0":
@@ -918,11 +922,11 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job) (
-                      rate(thanos_bucket_store_series_blocks_queried_sum{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_series_blocks_queried_sum{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   /
                     sum by (namespace, job) (
-                      rate(thanos_bucket_store_series_blocks_queried_count{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_series_blocks_queried_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                 seriesNameFormat: mean {{job}} {{namespace}}
         - kind: TimeSeriesQuery
@@ -937,7 +941,9 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -953,7 +959,9 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -969,7 +977,9 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -1000,12 +1010,14 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job, data_type) (
-                      rate(thanos_bucket_store_series_data_size_fetched_bytes_sum{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_series_data_size_fetched_bytes_sum{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   /
                     sum by (namespace, job, data_type) (
                       rate(
-                        thanos_bucket_store_series_data_size_fetched_bytes_count{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_fetched_bytes_count{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: mean {{job}} {{data_type}} {{namespace}}
@@ -1022,7 +1034,7 @@ spec:
                     0.5,
                     sum by (namespace, job, data_type, le) (
                       rate(
-                        thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1040,7 +1052,7 @@ spec:
                     0.9,
                     sum by (namespace, job, data_type, le) (
                       rate(
-                        thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1058,7 +1070,7 @@ spec:
                     0.99,
                     sum by (namespace, job, data_type, le) (
                       rate(
-                        thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1090,12 +1102,14 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job, data_type) (
-                      rate(thanos_bucket_store_series_data_size_touched_bytes_sum{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_series_data_size_touched_bytes_sum{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   /
                     sum by (namespace, job, data_type) (
                       rate(
-                        thanos_bucket_store_series_data_size_touched_bytes_count{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_touched_bytes_count{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                 seriesNameFormat: mean {{job}} {{data_type}} {{namespace}}
@@ -1112,7 +1126,7 @@ spec:
                     0.5,
                     sum by (namespace, job, data_type, le) (
                       rate(
-                        thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1130,7 +1144,7 @@ spec:
                     0.9,
                     sum by (namespace, job, data_type, le) (
                       rate(
-                        thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1148,7 +1162,7 @@ spec:
                     0.99,
                     sum by (namespace, job, data_type, le) (
                       rate(
-                        thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1180,11 +1194,11 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job) (
-                      rate(thanos_bucket_store_series_result_series_sum{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_series_result_series_sum{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   /
                     sum by (namespace, job) (
-                      rate(thanos_bucket_store_series_result_series_count{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_series_result_series_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                 seriesNameFormat: mean {{job}} {{namespace}}
         - kind: TimeSeriesQuery
@@ -1199,7 +1213,7 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -1215,7 +1229,7 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -1231,7 +1245,7 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   )
                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -1265,7 +1279,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1283,7 +1297,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1301,7 +1315,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1336,7 +1350,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1354,7 +1368,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1372,7 +1386,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1407,7 +1421,7 @@ spec:
                     0.5,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1425,7 +1439,7 @@ spec:
                     0.9,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1443,7 +1457,7 @@ spec:
                     0.99,
                     sum by (namespace, job, le) (
                       rate(
-                        thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                        thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                       )
                     )
                   )
@@ -1476,11 +1490,11 @@ spec:
                   name: prometheus-datasource
                 query: |2-
                     sum by (namespace, job) (
-                      rate(thanos_bucket_store_sent_chunk_size_bytes_sum{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_sent_chunk_size_bytes_sum{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                   /
                     sum by (namespace, job) (
-                      rate(thanos_bucket_store_sent_chunk_size_bytes_count{job=~"$job",namespace="$namespace"}[5m])
+                      rate(thanos_bucket_store_sent_chunk_size_bytes_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                     )
                 seriesNameFormat: mean {{job}} {{namespace}}
         - kind: TimeSeriesQuery
@@ -1495,7 +1509,9 @@ spec:
                   histogram_quantile(
                     0.5,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -1511,7 +1527,9 @@ spec:
                   histogram_quantile(
                     0.9,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -1527,7 +1545,9 @@ spec:
                   histogram_quantile(
                     0.99,
                     sum by (namespace, job, le) (
-                      rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[5m])
+                      rate(
+                        thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                      )
                     )
                   )
                 seriesNameFormat: p99 {{job}} {{namespace}}

--- a/examples/dashboards/operator/thanos-store-overview.yaml
+++ b/examples/dashboards/operator/thanos-store-overview.yaml
@@ -1603,7 +1603,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate All {{pod}}
         - kind: TimeSeriesQuery
           spec:
@@ -1613,7 +1613,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                 seriesNameFormat: Alloc Rate Heap {{pod}}
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/perses/alertmanager-overview.yaml
+++ b/examples/dashboards/perses/alertmanager-overview.yaml
@@ -92,7 +92,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: sum by (job, instance) (rate(alertmanager_alerts_received_total{job=~"$job"}[5m]))
+                                query: sum by (job, instance) (rate(alertmanager_alerts_received_total{job=~"$job"}[$__rate_interval]))
                                 seriesNameFormat: '{{instance}} - Alertmanager - Received'
                     - kind: TimeSeriesQuery
                       spec:
@@ -102,7 +102,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: sum by (job, instance) (rate(alertmanager_alerts_invalid_total{job=~"$job"}[5m]))
+                                query: sum by (job, instance) (rate(alertmanager_alerts_invalid_total{job=~"$job"}[$__rate_interval]))
                                 seriesNameFormat: '{{instance}} - Alertmanager - Invalid'
         "1_0":
             kind: Panel
@@ -129,7 +129,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (integration, instance) (
-                                      rate(alertmanager_notifications_total{integration=~"$integration",job=~"$job"}[5m])
+                                      rate(alertmanager_notifications_total{integration=~"$integration",job=~"$job"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{instance}} - {{integration}} - Total'
                     - kind: TimeSeriesQuery
@@ -142,7 +142,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (integration, instance) (
-                                      rate(alertmanager_notifications_failed_total{integration=~"$integration",job=~"$job"}[5m])
+                                      rate(alertmanager_notifications_failed_total{integration=~"$integration",job=~"$job"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{instance}} - {{integration}} - Failed'
         "1_1":
@@ -175,7 +175,9 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (le, integration, instance) (
-                                        rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                                        rate(
+                                          alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: '{{instance}} - {{integration}} - 99th Percentile'
@@ -191,7 +193,9 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (le, integration, instance) (
-                                        rate(alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[5m])
+                                        rate(
+                                          alertmanager_notification_latency_seconds_bucket{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: '{{instance}} - {{integration}} - Median'
@@ -205,11 +209,15 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (integration, instance) (
-                                        rate(alertmanager_notification_latency_seconds_sum{integration=~"$integration",job=~"$job"}[5m])
+                                        rate(
+                                          alertmanager_notification_latency_seconds_sum{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                                        )
                                       )
                                     /
                                       sum by (integration, instance) (
-                                        rate(alertmanager_notification_latency_seconds_count{integration=~"$integration",job=~"$job"}[5m])
+                                        rate(
+                                          alertmanager_notification_latency_seconds_count{integration=~"$integration",job=~"$job"}[$__rate_interval]
+                                        )
                                       )
                                 seriesNameFormat: '{{instance}} - {{integration}} - Average'
     layouts:

--- a/examples/dashboards/perses/kubernetes-cluster-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes-cluster-resources-overview.yaml
@@ -535,44 +535,8 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace) (
-                                      rate(container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
-                                    )
-                    - kind: TimeSeriesQuery
-                      spec:
-                        plugin:
-                            kind: PrometheusTimeSeriesQuery
-                            spec:
-                                datasource:
-                                    kind: PrometheusDatasource
-                                    name: prometheus-datasource
-                                query: |-
-                                    sum by (namespace) (
-                                      rate(container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
-                                    )
-                    - kind: TimeSeriesQuery
-                      spec:
-                        plugin:
-                            kind: PrometheusTimeSeriesQuery
-                            spec:
-                                datasource:
-                                    kind: PrometheusDatasource
-                                    name: prometheus-datasource
-                                query: |-
-                                    sum by (namespace) (
-                                      rate(container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
-                                    )
-                    - kind: TimeSeriesQuery
-                      spec:
-                        plugin:
-                            kind: PrometheusTimeSeriesQuery
-                            spec:
-                                datasource:
-                                    kind: PrometheusDatasource
-                                    name: prometheus-datasource
-                                query: |-
-                                    sum by (namespace) (
                                       rate(
-                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                                        container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -586,7 +550,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       rate(
-                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                                        container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -600,7 +564,49 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       rate(
-                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                                        container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                                      )
+                                    )
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (namespace) (
+                                      rate(
+                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                                      )
+                                    )
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (namespace) (
+                                      rate(
+                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                                      )
+                                    )
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (namespace) (
+                                      rate(
+                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                                       )
                                     )
         "6_0":
@@ -636,7 +642,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace) (
-                                      rate(container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                                      rate(
+                                        container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}}'
         "6_1":
@@ -672,7 +680,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace) (
-                                      rate(container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                                      rate(
+                                        container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}}'
         "7_0":
@@ -708,7 +718,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     avg by (namespace) (
-                                      irate(container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                                      irate(
+                                        container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}}'
         "7_1":
@@ -744,7 +756,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     avg by (namespace) (
-                                      irate(container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m])
+                                      irate(
+                                        container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}}'
         "8_0":
@@ -781,7 +795,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       irate(
-                                        container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                                        container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}}'
@@ -819,7 +833,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       irate(
-                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}}'
@@ -857,7 +871,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       irate(
-                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}}'
@@ -895,7 +909,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       irate(
-                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[5m]
+                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace=~".+"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}}'
@@ -934,10 +948,12 @@ spec:
                                     ceil(
                                       sum by (namespace) (
                                           rate(
-                                            container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                            container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                           )
                                         +
-                                          rate(container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[5m])
+                                          rate(
+                                            container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[$__rate_interval]
+                                          )
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}}'
@@ -975,11 +991,11 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                         rate(
-                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[5m]
+                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace!=""}[$__rate_interval]
                                         )
                                     )
                                 seriesNameFormat: '{{namespace}}'
@@ -1031,7 +1047,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       rate(
-                                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1045,7 +1061,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       rate(
-                                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1059,11 +1075,11 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                         rate(
-                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                         )
                                     )
                     - kind: TimeSeriesQuery
@@ -1077,7 +1093,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       rate(
-                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1091,7 +1107,7 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                       rate(
-                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1105,11 +1121,11 @@ spec:
                                 query: |-
                                     sum by (namespace) (
                                         rate(
-                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[5m]
+                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace!=""}[$__rate_interval]
                                         )
                                     )
     layouts:

--- a/examples/dashboards/perses/kubernetes-namespace-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes-namespace-resources-overview.yaml
@@ -595,7 +595,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -609,7 +609,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -623,7 +623,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -637,7 +637,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -651,7 +651,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -665,7 +665,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
         "6_0":
@@ -701,7 +701,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (pod) (
-                                      rate(container_network_receive_bytes_total{cluster="$cluster",namespace="$namespace"}[5m])
+                                      rate(container_network_receive_bytes_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{pod}}'
         "6_1":
@@ -737,7 +737,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (pod) (
-                                      rate(container_network_transmit_bytes_total{cluster="$cluster",namespace="$namespace"}[5m])
+                                      rate(container_network_transmit_bytes_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{pod}}'
         "7_0":
@@ -773,7 +773,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (pod) (
-                                      irate(container_network_receive_packets_total{cluster="$cluster",namespace="$namespace"}[5m])
+                                      irate(container_network_receive_packets_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{pod}}'
         "7_1":
@@ -809,7 +809,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (pod) (
-                                      irate(container_network_transmit_packets_total{cluster="$cluster",namespace="$namespace"}[5m])
+                                      irate(
+                                        container_network_transmit_packets_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{pod}}'
         "8_0":
@@ -846,7 +848,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       irate(
-                                        container_network_receive_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[5m]
+                                        container_network_receive_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -884,7 +886,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       irate(
-                                        container_network_transmit_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[5m]
+                                        container_network_transmit_packets_dropped_total{cluster="$cluster",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -923,11 +925,11 @@ spec:
                                     ceil(
                                       sum by (pod) (
                                           rate(
-                                            container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                                            container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                                           )
                                         +
                                           rate(
-                                            container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                                            container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                                           )
                                       )
                                     )
@@ -966,11 +968,11 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                         rate(
-                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[5m]
+                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",namespace="$namespace"}[$__rate_interval]
                                         )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -1022,7 +1024,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1036,7 +1038,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1050,11 +1052,11 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                         rate(
-                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                         )
                                     )
                     - kind: TimeSeriesQuery
@@ -1068,7 +1070,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1082,7 +1084,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1096,11 +1098,11 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                         rate(
-                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[5m]
+                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                         )
                                     )
     layouts:

--- a/examples/dashboards/perses/kubernetes-pod-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes-pod-resources-overview.yaml
@@ -157,13 +157,13 @@ spec:
                                 query: |4-
                                       sum by (container) (
                                         increase(
-                                          container_cpu_cfs_throttled_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_cpu_cfs_throttled_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                       )
                                     /
                                       sum by (container) (
                                         increase(
-                                          container_cpu_cfs_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_cpu_cfs_periods_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{container}}'
@@ -512,7 +512,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       irate(
-                                        container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -550,7 +550,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -588,7 +588,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -626,7 +626,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -664,7 +664,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -702,7 +702,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{pod}}'
@@ -741,7 +741,7 @@ spec:
                                     ceil(
                                       sum by (pod) (
                                         rate(
-                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -758,7 +758,7 @@ spec:
                                     ceil(
                                       sum by (pod) (
                                         rate(
-                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -797,7 +797,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: Writes
@@ -812,7 +812,7 @@ spec:
                                 query: |-
                                     sum by (pod) (
                                       rate(
-                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[5m]
+                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod=~"$pod"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: Reads
@@ -851,11 +851,11 @@ spec:
                                     ceil(
                                       sum by (container) (
                                           rate(
-                                            container_fs_reads_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                            container_fs_reads_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                           )
                                         +
                                           rate(
-                                            container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                            container_fs_writes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                           )
                                       )
                                     )
@@ -894,11 +894,11 @@ spec:
                                 query: |-
                                     sum by (container) (
                                         rate(
-                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                     )
                                 seriesNameFormat: '{{container}}'
@@ -950,7 +950,7 @@ spec:
                                 query: |-
                                     sum by (container) (
                                       rate(
-                                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                        container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -964,7 +964,7 @@ spec:
                                 query: |-
                                     sum by (container) (
                                       rate(
-                                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                        container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -978,11 +978,11 @@ spec:
                                 query: |-
                                     sum by (container) (
                                         rate(
-                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_fs_reads_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_fs_writes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                     )
                     - kind: TimeSeriesQuery
@@ -996,7 +996,7 @@ spec:
                                 query: |-
                                     sum by (container) (
                                       rate(
-                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                        container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1010,7 +1010,7 @@ spec:
                                 query: |-
                                     sum by (container) (
                                       rate(
-                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                        container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                       )
                                     )
                     - kind: TimeSeriesQuery
@@ -1024,11 +1024,11 @@ spec:
                                 query: |-
                                     sum by (container) (
                                         rate(
-                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_fs_reads_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                       +
                                         rate(
-                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[5m]
+                                          container_fs_writes_bytes_total{cluster="$cluster",container!="",device=~"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+",job="cadvisor",namespace="$namespace",pod="$pod"}[$__rate_interval]
                                         )
                                     )
     layouts:

--- a/examples/dashboards/perses/kubernetes-workload-ns-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes-workload-ns-resources-overview.yaml
@@ -512,7 +512,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -530,7 +530,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -548,7 +548,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -566,7 +566,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -584,7 +584,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -602,7 +602,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload_type=~"$type"}
@@ -643,7 +643,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -685,7 +685,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -727,7 +727,7 @@ spec:
                                     (
                                       avg by (workload) (
                                           rate(
-                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -769,7 +769,7 @@ spec:
                                     (
                                       avg by (workload) (
                                           rate(
-                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -811,7 +811,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -853,7 +853,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -895,7 +895,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}
@@ -937,7 +937,7 @@ spec:
                                     (
                                       sum by (workload) (
                                           rate(
-                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~".+",workload_type=~"$type"}

--- a/examples/dashboards/perses/kubernetes-workload-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes-workload-resources-overview.yaml
@@ -435,7 +435,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -453,7 +453,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -471,7 +471,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -489,7 +489,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -507,7 +507,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -525,7 +525,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -566,7 +566,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -608,7 +608,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -650,7 +650,7 @@ spec:
                                     (
                                       avg by (pod) (
                                           rate(
-                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -692,7 +692,7 @@ spec:
                                     (
                                       avg by (pod) (
                                           rate(
-                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_bytes_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -734,7 +734,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -776,7 +776,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -818,7 +818,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_receive_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}
@@ -860,7 +860,7 @@ spec:
                                     (
                                       sum by (pod) (
                                           rate(
-                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[5m]
+                                            container_network_transmit_packets_dropped_total{cluster="$cluster",job="cadvisor",namespace="$namespace"}[$__rate_interval]
                                           )
                                         * on (namespace, pod) group_left (workload, workload_type)
                                           namespace_workload_pod:kube_pod_owner:relabel{cluster="$cluster",namespace="$namespace",workload=~"$workload",workload_type=~"$type"}

--- a/examples/dashboards/perses/node-exporter-nodes.yaml
+++ b/examples/dashboards/perses/node-exporter-nodes.yaml
@@ -59,7 +59,7 @@ spec:
                                             1
                                           -
                                             sum without (mode) (
-                                              rate(node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[5m])
+                                              rate(node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval])
                                             )
                                         )
                                       / ignoring (cpu) group_left ()
@@ -236,7 +236,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[5m])
+                                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Disk - Usage'
                     - kind: TimeSeriesQuery
                       spec:
@@ -246,7 +246,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Disk - Written'
         "2_1":
             kind: Panel
@@ -274,7 +274,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[5m])
+                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Disk - IO Time'
         "3_0":
             kind: Panel
@@ -302,7 +302,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                                query: rate(node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Network - Received'
         "3_1":
             kind: Panel
@@ -330,7 +330,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_network_transmit_bytes_total{device!="lo",instance="$instance",job="node"}[5m])
+                                query: rate(node_network_transmit_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Network - Transmitted'
     layouts:
         - kind: Grid

--- a/examples/dashboards/perses/perses-overview.yaml
+++ b/examples/dashboards/perses/perses-overview.yaml
@@ -223,7 +223,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_alloc_bytes_total{instance=~"$instance",job=~"$job"}[5m])
+                                query: rate(go_memstats_alloc_bytes_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate All {{pod}}
                     - kind: TimeSeriesQuery
                       spec:
@@ -233,7 +233,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_heap_alloc_bytes{instance=~"$instance",job=~"$job"}[5m])
+                                query: rate(go_memstats_heap_alloc_bytes{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate Heap {{pod}}
                     - kind: TimeSeriesQuery
                       spec:

--- a/examples/dashboards/perses/perses-overview.yaml
+++ b/examples/dashboards/perses/perses-overview.yaml
@@ -106,11 +106,11 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (handler, method) (
-                                        rate(perses_http_request_duration_second_sum{instance=~"$instance",job=~"$job"}[5m])
+                                        rate(perses_http_request_duration_second_sum{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                       )
                                     /
                                       sum by (handler, method) (
-                                        rate(perses_http_request_duration_second_count{instance=~"$instance",job=~"$job"}[5m])
+                                        rate(perses_http_request_duration_second_count{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                       )
                                 seriesNameFormat: '{{handler}} {{method}}'
         "1_1":
@@ -137,7 +137,10 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: sum by (handler, code) (rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[5m]))
+                                query: |-
+                                    sum by (handler, code) (
+                                      rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
+                                    )
                                 seriesNameFormat: '{{handler}} {{method}} {{code}}'
         "1_2":
             kind: Panel
@@ -165,7 +168,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (handler, code) (
-                                      rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[5m])
+                                      rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{handler}} {{method}} {{code}}'
         "2_0":
@@ -288,7 +291,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(process_cpu_seconds_total{instance=~"$instance",job=~"$job"}[5m])
+                                query: rate(process_cpu_seconds_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                 seriesNameFormat: '{{pod}}'
         "2_2":
             kind: Panel

--- a/examples/dashboards/perses/prometheus-overview.yaml
+++ b/examples/dashboards/perses/prometheus-overview.yaml
@@ -99,7 +99,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (job, scrape_job, instance) (
-                                      rate(prometheus_target_sync_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                                      rate(prometheus_target_sync_length_seconds_sum{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} - {{instance}} - Metrics'
         "1_1":
@@ -150,9 +150,9 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: |4-
-                                      rate(prometheus_target_interval_length_seconds_sum{instance=~"$instance",job=~"$job"}[5m])
+                                      rate(prometheus_target_interval_length_seconds_sum{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                     /
-                                      rate(prometheus_target_interval_length_seconds_count{instance=~"$instance",job=~"$job"}[5m])
+                                      rate(prometheus_target_interval_length_seconds_count{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                 seriesNameFormat: '{{job}} - {{instance}} - {{interval}} Configured'
         "2_1":
             kind: Panel
@@ -178,7 +178,7 @@ spec:
                                 query: |-
                                     sum by (job, instance) (
                                       rate(
-                                        prometheus_target_scrapes_exceeded_body_size_limit_total{instance=~"$instance",job=~"$job"}[1m]
+                                        prometheus_target_scrapes_exceeded_body_size_limit_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: 'exceeded body size limit: {{job}} - {{instance}} - Metrics'
@@ -192,7 +192,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (job, instance) (
-                                      rate(prometheus_target_scrapes_exceeded_sample_limit_total{instance=~"$instance",job=~"$job"}[1m])
+                                      rate(
+                                        prometheus_target_scrapes_exceeded_sample_limit_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: 'exceeded sample limit: {{job}} - {{instance}} - Metrics'
                     - kind: TimeSeriesQuery
@@ -206,7 +208,7 @@ spec:
                                 query: |-
                                     sum by (job, instance) (
                                       rate(
-                                        prometheus_target_scrapes_sample_duplicate_timestamp_total{instance=~"$instance",job=~"$job"}[1m]
+                                        prometheus_target_scrapes_sample_duplicate_timestamp_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: 'duplicate timestamp: {{job}} - {{instance}} - Metrics'
@@ -220,7 +222,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (job, instance) (
-                                      rate(prometheus_target_scrapes_sample_out_of_bounds_total{instance=~"$instance",job=~"$job"}[1m])
+                                      rate(
+                                        prometheus_target_scrapes_sample_out_of_bounds_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: 'out of bounds: {{job}} - {{instance}} - Metrics'
                     - kind: TimeSeriesQuery
@@ -233,7 +237,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (job, instance) (
-                                      rate(prometheus_target_scrapes_sample_out_of_order_total{instance=~"$instance",job=~"$job"}[1m])
+                                      rate(
+                                        prometheus_target_scrapes_sample_out_of_order_total{instance=~"$instance",job=~"$job"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: 'out of order: {{job}} - {{instance}} - Metrics'
         "2_2":
@@ -257,7 +263,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(prometheus_tsdb_head_samples_appended_total{instance=~"$instance",job=~"$job"}[5m])
+                                query: rate(prometheus_tsdb_head_samples_appended_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                 seriesNameFormat: '{{job}} - {{instance}} - {{remote_name}} - {{url}}'
         "3_0":
             kind: Panel
@@ -328,7 +334,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     rate(
-                                      prometheus_engine_query_duration_seconds_count{instance=~"$instance",job=~"$job",slice="inner_eval"}[5m]
+                                      prometheus_engine_query_duration_seconds_count{instance=~"$instance",job=~"$job",slice="inner_eval"}[$__rate_interval]
                                     )
                                 seriesNameFormat: '{{job}} - {{instance}} - Query Rate'
         "4_1":

--- a/examples/dashboards/perses/prometheus-remote-write.yaml
+++ b/examples/dashboards/perses/prometheus-remote-write.yaml
@@ -80,7 +80,7 @@ spec:
             kind: Panel
             spec:
                 display:
-                    name: Rate[5m]
+                    name: Rate
                     description: Shows rate metrics over 5 minute intervals
                 plugin:
                     kind: TimeSeriesChart
@@ -99,10 +99,10 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     clamp_min(
-                                        rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}[5m])
+                                        rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~"$instance"}[$__rate_interval])
                                       - ignoring (remote_name, url) group_right (instance)
                                         rate(
-                                          prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}[5m]
+                                          prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~"$instance",url="$url"}[$__rate_interval]
                                         ),
                                       0
                                     )
@@ -111,7 +111,7 @@ spec:
             kind: Panel
             spec:
                 display:
-                    name: Rate, in vs. succeeded or dropped [5m]
+                    name: Rate, in vs. succeeded or dropped
                     description: Shows rate of samples in remote storage
                 plugin:
                     kind: TimeSeriesChart
@@ -129,18 +129,18 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: |4-
-                                        rate(prometheus_remote_storage_samples_in_total{instance=~"$instance"}[5m])
+                                        rate(prometheus_remote_storage_samples_in_total{instance=~"$instance"}[$__rate_interval])
                                       - ignoring (remote_name, url) group_right (instance)
                                         (
-                                            rate(prometheus_remote_storage_succeeded_samples_total{instance=~"$instance",url="$url"}[5m])
+                                            rate(prometheus_remote_storage_succeeded_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                           or
-                                            rate(prometheus_remote_storage_samples_total{instance=~"$instance",url="$url"}[5m])
+                                            rate(prometheus_remote_storage_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                         )
                                     -
                                       (
-                                          rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                                          rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                         or
-                                          rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                                          rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                       )
                                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
         "2_0":
@@ -352,9 +352,9 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: |4-
-                                      rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[5m])
+                                      rate(prometheus_remote_storage_dropped_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                     or
-                                      rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[5m])
+                                      rate(prometheus_remote_storage_samples_dropped_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
         "5_1":
             kind: Panel
@@ -378,9 +378,9 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: |4-
-                                      rate(prometheus_remote_storage_failed_samples_total{instance=~"$instance",url="$url"}[5m])
+                                      rate(prometheus_remote_storage_failed_samples_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                     or
-                                      rate(prometheus_remote_storage_samples_failed_total{instance=~"$instance",url="$url"}[5m])
+                                      rate(prometheus_remote_storage_samples_failed_total{instance=~"$instance",url="$url"}[$__rate_interval])
                                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
         "5_2":
             kind: Panel
@@ -404,9 +404,9 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: |4-
-                                      rate(prometheus_remote_storage_retried_samples_total{instance=~"$instance",url=~"$url"}[5m])
+                                      rate(prometheus_remote_storage_retried_samples_total{instance=~"$instance",url=~"$url"}[$__rate_interval])
                                     or
-                                      rate(prometheus_remote_storage_samples_retried_total{instance=~"$instance",url=~"$url"}[5m])
+                                      rate(prometheus_remote_storage_samples_retried_total{instance=~"$instance",url=~"$url"}[$__rate_interval])
                                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
         "5_3":
             kind: Panel
@@ -429,7 +429,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(prometheus_remote_storage_enqueue_retries_total{instance=~"$instance",url=~"$url"}[5m])
+                                query: rate(prometheus_remote_storage_enqueue_retries_total{instance=~"$instance",url=~"$url"}[$__rate_interval])
                                 seriesNameFormat: '{{instance}} - {{remote_name}} - {{url}} - Metrics'
     layouts:
         - kind: Grid

--- a/examples/dashboards/perses/thanos-compact-overview.yaml
+++ b/examples/dashboards/perses/thanos-compact-overview.yaml
@@ -921,7 +921,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate All {{pod}}
                     - kind: TimeSeriesQuery
                       spec:
@@ -931,7 +931,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate Heap {{pod}}
                     - kind: TimeSeriesQuery
                       spec:

--- a/examples/dashboards/perses/thanos-compact-overview.yaml
+++ b/examples/dashboards/perses/thanos-compact-overview.yaml
@@ -174,7 +174,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, resolution) (
-                                      rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: 'Resolution: {{resolution}} - {{job}} {{namespace}}'
         "1_1":
@@ -204,11 +204,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job) (
-                                            rate(thanos_compact_group_compactions_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_compact_group_compactions_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         /
                                           sum by (namespace, job) (
-                                            rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_compact_group_compactions_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -240,7 +240,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, resolution) (
-                                      rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: 'Resolution: {{resolution}} - {{job}} {{namespace}}'
         "2_1":
@@ -270,11 +270,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job) (
-                                            rate(thanos_compact_downsample_failed_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_compact_downsample_failed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         /
                                           sum by (namespace, job) (
-                                            rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_compact_downsample_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -308,7 +308,9 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, resolution, le) (
-                                        rate(thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: 'p50 Resolution: {{resolution}} - {{job}} {{namespace}}'
@@ -324,7 +326,9 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, resolution, le) (
-                                        rate(thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: 'p90 Resolution: {{resolution}} - {{job}} {{namespace}}'
@@ -340,7 +344,9 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, resolution, le) (
-                                        rate(thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_compact_downsample_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: 'p99 Resolution: {{resolution}} - {{job}} {{namespace}}'
@@ -370,7 +376,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "3_1":
@@ -400,11 +406,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job) (
-                                            rate(thanos_blocks_meta_sync_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_blocks_meta_sync_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         /
                                           sum by (namespace, job) (
-                                            rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_blocks_meta_syncs_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -438,7 +444,7 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -454,7 +460,7 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -470,7 +476,7 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_blocks_meta_sync_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -500,7 +506,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_compact_blocks_cleaned_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_compact_blocks_cleaned_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "4_1":
@@ -529,7 +535,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_compact_block_cleanup_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_compact_block_cleanup_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "4_2":
@@ -559,7 +565,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job) (
                                       rate(
-                                        thanos_compact_blocks_marked_total{job=~"$job",marker="deletion-mark.json",namespace="$namespace"}[5m]
+                                        thanos_compact_blocks_marked_total{job=~"$job",marker="deletion-mark.json",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
@@ -589,7 +595,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, operation) (
-                                      rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{operation}} {{namespace}}'
         "5_1":
@@ -619,11 +625,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job, operation) (
-                                            rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         /
                                           sum by (namespace, job, operation) (
-                                            rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -658,7 +664,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, operation, le) (
                                         rate(
-                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -676,7 +682,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, operation, le) (
                                         rate(
-                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -694,7 +700,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, operation, le) (
                                         rate(
-                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -751,7 +757,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "7_1":
@@ -781,11 +787,13 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job) (
-                                            rate(thanos_compact_garbage_collection_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(
+                                              thanos_compact_garbage_collection_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                            )
                                           )
                                         /
                                           sum by (namespace, job) (
-                                            rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_compact_garbage_collection_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -820,7 +828,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -838,7 +846,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -856,7 +864,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_compact_garbage_collection_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )

--- a/examples/dashboards/perses/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/perses/thanos-query-frontend-overview.yaml
@@ -70,7 +70,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, handler, code) (
-                                      rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{code}} - {{job}} {{namespace}}'
         "0_1":
@@ -99,7 +99,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, handler, code) (
-                                      rate(thanos_query_frontend_queries_total{job=~"$job",namespace="$namespace",op="query_range"}[5m])
+                                      rate(
+                                        thanos_query_frontend_queries_total{job=~"$job",namespace="$namespace",op="query_range"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{code}} - {{job}} {{namespace}}'
         "0_2":
@@ -129,12 +131,12 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, code) (
                                         rate(
-                                          http_requests_total{code=~"5..",handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                                          http_requests_total{code=~"5..",handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (code) group_left ()
                                       sum by (namespace, job) (
-                                        rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(http_requests_total{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                 seriesNameFormat: '{{code}} - {{job}} {{namespace}}'
         "0_3":
@@ -166,7 +168,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                                          http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -184,7 +186,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                                          http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -202,7 +204,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[5m]
+                                          http_request_duration_seconds_bucket{handler="query-frontend",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -233,7 +235,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, tripperware) (
-                                      rate(cortex_cache_request_duration_seconds_count{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(cortex_cache_request_duration_seconds_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
         "1_1":
@@ -262,7 +264,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, tripperware) (
-                                      rate(cortex_cache_hits_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(cortex_cache_hits_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
         "1_2":
@@ -291,7 +293,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, tripperware) (
-                                      rate(querier_cache_misses_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(querier_cache_misses_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
         "1_3":
@@ -320,7 +322,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, tripperware) (
-                                      rate(cortex_cache_fetched_keys_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(cortex_cache_fetched_keys_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{tripperware}} - {{job}} {{namespace}}'
         "2_0":

--- a/examples/dashboards/perses/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/perses/thanos-query-frontend-overview.yaml
@@ -377,7 +377,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate All {{pod}}
                     - kind: TimeSeriesQuery
                       spec:
@@ -387,7 +387,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate Heap {{pod}}
                     - kind: TimeSeriesQuery
                       spec:

--- a/examples/dashboards/perses/thanos-query-overview.yaml
+++ b/examples/dashboards/perses/thanos-query-overview.yaml
@@ -70,7 +70,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, handler, code) (
-                                      rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}} {{handler}} {{code}}'
         "0_1":
@@ -100,11 +100,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job, code) (
-                                            rate(http_requests_total{code=~"5..",handler="query",job=~"$job",namespace="$namespace"}[5m])
+                                            rate(http_requests_total{code=~"5..",handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         / ignoring (code) group_left ()
                                           sum by (namespace, job) (
-                                            rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                                            rate(http_requests_total{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -138,7 +138,9 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, le) (
-                                        rate(http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p50 {{job}} - {{namespace}} duration
@@ -154,7 +156,9 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, le) (
-                                        rate(http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p90 {{job}} - {{namespace}} duration
@@ -170,7 +174,9 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, le) (
-                                        rate(http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          http_request_duration_seconds_bucket{handler="query",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p99 {{job}} {{namespace}} duration
@@ -200,7 +206,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, handler, code) (
-                                      rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}} {{handler}} {{code}}'
         "1_1":
@@ -230,11 +236,13 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job, code) (
-                                            rate(http_requests_total{code=~"5..",handler="query_range",job=~"$job",namespace="$namespace"}[5m])
+                                            rate(
+                                              http_requests_total{code=~"5..",handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                            )
                                           )
                                         / ignoring (code) group_left ()
                                           sum by (namespace, job) (
-                                            rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[5m])
+                                            rate(http_requests_total{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -269,7 +277,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[5m]
+                                          http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -287,7 +295,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[5m]
+                                          http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -305,7 +313,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[5m]
+                                          http_request_duration_seconds_bucket{handler="query_range",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -337,7 +345,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
                                       rate(
-                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -368,13 +376,13 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
                                         rate(
-                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -407,7 +415,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -425,7 +433,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -443,7 +451,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -474,7 +482,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
-                                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(
+                                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "3_1":
@@ -504,12 +514,14 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
-                                        rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "3_2":
@@ -541,7 +553,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -559,7 +571,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -577,7 +589,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -604,10 +616,12 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: |4-
-                                      max_over_time(thanos_query_concurrent_gate_queries_max{job=~"$job",namespace="$namespace"}[5m])
+                                      max_over_time(
+                                        thanos_query_concurrent_gate_queries_max{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                      )
                                     -
                                       avg_over_time(
-                                        thanos_query_concurrent_gate_queries_in_flight{job=~"$job",namespace="$namespace"}[5m]
+                                        thanos_query_concurrent_gate_queries_in_flight{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                       )
                                 seriesNameFormat: '{{job}} {{pod}}'
         "5_0":
@@ -636,7 +650,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}}'
         "5_1":
@@ -665,11 +679,11 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job) (
-                                        rate(thanos_query_store_apis_dns_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_query_store_apis_dns_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     /
                                       sum by (namespace, job) (
-                                        rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_query_store_apis_dns_lookups_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                 seriesNameFormat: '{{job}}'
         "6_0":

--- a/examples/dashboards/perses/thanos-query-overview.yaml
+++ b/examples/dashboards/perses/thanos-query-overview.yaml
@@ -738,7 +738,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate All {{pod}}
                     - kind: TimeSeriesQuery
                       spec:
@@ -748,7 +748,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate Heap {{pod}}
                     - kind: TimeSeriesQuery
                       spec:

--- a/examples/dashboards/perses/thanos-receive-overview.yaml
+++ b/examples/dashboards/perses/thanos-receive-overview.yaml
@@ -1211,7 +1211,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate All {{pod}}
                     - kind: TimeSeriesQuery
                       spec:
@@ -1221,7 +1221,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate Heap {{pod}}
                     - kind: TimeSeriesQuery
                       spec:

--- a/examples/dashboards/perses/thanos-receive-overview.yaml
+++ b/examples/dashboards/perses/thanos-receive-overview.yaml
@@ -87,7 +87,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, handler, code) (
-                                      rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}} {{handler}} {{code}}'
         "0_1":
@@ -117,11 +117,13 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job, code) (
-                                            rate(http_requests_total{code=~"5..",handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                                            rate(
+                                              http_requests_total{code=~"5..",handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                            )
                                           )
                                         / ignoring (code) group_left ()
                                           sum by (namespace, job) (
-                                            rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                                            rate(http_requests_total{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -155,7 +157,9 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, le) (
-                                        rate(http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p50 {{job}} - {{namespace}} duration
@@ -171,7 +175,9 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, le) (
-                                        rate(http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p90 {{job}} - {{namespace}} duration
@@ -187,7 +193,9 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, le) (
-                                        rate(http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          http_request_duration_seconds_bucket{handler="receive",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p99 {{job}} {{namespace}} duration
@@ -218,7 +226,7 @@ spec:
                                 query: |-
                                     sum by (tenant, job, handler, code) (
                                       rate(
-                                        http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                        http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{tenant}} {{code}} {{job}} {{namespace}} {{handler}}'
@@ -250,13 +258,13 @@ spec:
                                       (
                                           sum by (tenant, namespace, job, code) (
                                             rate(
-                                              http_requests_total{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                              http_requests_total{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                             )
                                           )
                                         / ignoring (code) group_left ()
                                           sum by (tenant, namespace, job) (
                                             rate(
-                                              http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                              http_requests_total{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                             )
                                           )
                                       )
@@ -290,7 +298,7 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, tenant) (
                                         rate(
-                                          http_request_duration_seconds_sum{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                          http_request_duration_seconds_sum{handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                         )
                                       )
                                     /
@@ -325,13 +333,13 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, tenant) (
                                         rate(
-                                          http_request_size_bytes_sum{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                          http_request_size_bytes_sum{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                         )
                                       )
                                     /
                                       sum by (namespace, job, tenant) (
                                         rate(
-                                          http_request_size_bytes_count{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                          http_request_size_bytes_count{code=~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{tenant}}'
@@ -362,13 +370,13 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, tenant) (
                                         rate(
-                                          http_request_size_bytes_sum{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                          http_request_size_bytes_sum{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                         )
                                       )
                                     /
                                       sum by (namespace, job, tenant) (
                                         rate(
-                                          http_request_size_bytes_count{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                          http_request_size_bytes_count{code!~"2..",handler="receive",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{tenant}}'
@@ -425,7 +433,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, tenant) (
                                       rate(
-                                        thanos_receive_write_timeseries_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                        thanos_receive_write_timeseries_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{tenant}}'
@@ -453,7 +461,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, tenant) (
                                       rate(
-                                        thanos_receive_write_timeseries_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                        thanos_receive_write_timeseries_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{tenant}}'
@@ -481,7 +489,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, tenant) (
                                       rate(
-                                        thanos_receive_write_samples_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                        thanos_receive_write_samples_sum{code=~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{tenant}}'
@@ -509,7 +517,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, tenant) (
                                       rate(
-                                        thanos_receive_write_samples_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[5m]
+                                        thanos_receive_write_samples_sum{code!~"2..",job=~"$job",namespace="$namespace",tenant=~"$tenant"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{tenant}}'
@@ -539,7 +547,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_receive_replications_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_receive_replications_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}}'
         "4_1":
@@ -568,7 +576,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_receive_replications_total{job=~"$job",namespace="$namespace",result="error"}[5m])
+                                      rate(
+                                        thanos_receive_replications_total{job=~"$job",namespace="$namespace",result="error"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{job}}'
         "5_0":
@@ -597,7 +607,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}}'
         "5_1":
@@ -626,7 +636,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace",result="error"}[5m])
+                                      rate(
+                                        thanos_receive_forward_requests_total{job=~"$job",namespace="$namespace",result="error"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{job}}'
         "6_0":
@@ -656,7 +668,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
                                       rate(
-                                        grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                        grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -687,13 +699,13 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
                                         rate(
-                                          grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -726,7 +738,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -744,7 +756,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -762,7 +774,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -794,7 +806,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
                                       rate(
-                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -825,13 +837,13 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
                                         rate(
-                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -864,7 +876,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -882,7 +894,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -900,7 +912,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -931,7 +943,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
-                                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(
+                                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "8_1":
@@ -961,12 +975,14 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
-                                        rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "8_2":
@@ -998,7 +1014,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1016,7 +1032,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1034,7 +1050,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1095,7 +1111,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(prometheus_tsdb_head_samples_appended_total{job=~"$job",namespace=~"$namespace"}[5m])
+                                query: rate(prometheus_tsdb_head_samples_appended_total{job=~"$job",namespace=~"$namespace"}[$__rate_interval])
                                 seriesNameFormat: '{{job}} - {{namespace}}'
         "10_1":
             kind: Panel

--- a/examples/dashboards/perses/thanos-ruler-overview.yaml
+++ b/examples/dashboards/perses/thanos-ruler-overview.yaml
@@ -70,7 +70,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, rule_group, strategy) (
-                                      rate(prometheus_rule_evaluations_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(prometheus_rule_evaluations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{rule_group}} {{strategy}} - {{job}} {{namespace}}'
         "0_1":
@@ -99,7 +99,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, rule_group, strategy) (
-                                      rate(prometheus_rule_evaluation_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(prometheus_rule_evaluation_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{rule_group}} {{strategy}} - {{job}} {{namespace}}'
         "0_2":
@@ -128,7 +128,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, rule_group, strategy) (
-                                      rate(prometheus_rule_group_iterations_missed_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(prometheus_rule_group_iterations_missed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{rule_group}} {{strategy}} - {{job}} {{namespace}}'
         "0_3":
@@ -192,7 +192,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, alertmanager) (
-                                      rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{alertmanager}} - {{job}} {{namespace}}'
         "1_1":
@@ -221,7 +221,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, alertmanager) (
-                                      rate(thanos_alert_sender_alerts_dropped_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_alert_sender_alerts_dropped_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{alertmanager}} - {{job}} {{namespace}}'
         "1_2":
@@ -250,11 +250,11 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job) (
-                                        rate(thanos_alert_sender_errors_total{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_alert_sender_errors_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     /
                                       sum by (namespace, job) (
-                                        rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_alert_sender_alerts_sent_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "1_3":
@@ -285,7 +285,7 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -301,7 +301,7 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -317,7 +317,7 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_alert_sender_latency_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -347,7 +347,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "2_1":
@@ -376,7 +376,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_alert_queue_alerts_popped_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_alert_queue_alerts_popped_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "2_2":
@@ -405,11 +405,11 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job) (
-                                        rate(thanos_alert_queue_alerts_dropped_total{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_alert_queue_alerts_dropped_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     /
                                       sum by (namespace, job) (
-                                        rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_alert_queue_alerts_pushed_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "3_0":
@@ -439,7 +439,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
                                       rate(
-                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -470,13 +470,13 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
                                         rate(
-                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -509,7 +509,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -527,7 +527,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -545,7 +545,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -576,7 +576,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
-                                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(
+                                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "4_1":
@@ -606,12 +608,14 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
-                                        rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "4_2":
@@ -643,7 +647,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -661,7 +665,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -679,7 +683,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )

--- a/examples/dashboards/perses/thanos-ruler-overview.yaml
+++ b/examples/dashboards/perses/thanos-ruler-overview.yaml
@@ -740,7 +740,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate All {{pod}}
                     - kind: TimeSeriesQuery
                       spec:
@@ -750,7 +750,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate Heap {{pod}}
                     - kind: TimeSeriesQuery
                       spec:

--- a/examples/dashboards/perses/thanos-store-overview.yaml
+++ b/examples/dashboards/perses/thanos-store-overview.yaml
@@ -1403,7 +1403,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_alloc_bytes_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate All {{pod}}
                     - kind: TimeSeriesQuery
                       spec:
@@ -1413,7 +1413,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[5m])
+                                query: rate(go_memstats_heap_alloc_bytes{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                 seriesNameFormat: Alloc Rate Heap {{pod}}
                     - kind: TimeSeriesQuery
                       spec:

--- a/examples/dashboards/perses/thanos-store-overview.yaml
+++ b/examples/dashboards/perses/thanos-store-overview.yaml
@@ -71,7 +71,7 @@ spec:
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
                                       rate(
-                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                        grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                       )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -102,13 +102,13 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
                                         rate(
-                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
@@ -141,7 +141,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -159,7 +159,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -177,7 +177,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_method!="RemoteWrite",grpc_type="unary",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -208,7 +208,9 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, grpc_method, grpc_code) (
-                                      rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                      rate(
+                                        grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                      )
                                     )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "1_1":
@@ -238,12 +240,14 @@ spec:
                                 query: |4-
                                       sum by (namespace, job, grpc_code) (
                                         rate(
-                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss",grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     / ignoring (grpc_code) group_left ()
                                       sum by (namespace, job) (
-                                        rate(grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          grpc_server_handled_total{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                 seriesNameFormat: '{{namespace}} {{job}} {{grpc_method}} {{grpc_code}}'
         "1_2":
@@ -275,7 +279,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -293,7 +297,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -311,7 +315,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[5m]
+                                          grpc_server_handling_seconds_bucket{grpc_type="server_stream",job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -342,7 +346,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, operation) (
-                                      rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{operation}} {{namespace}}'
         "2_1":
@@ -372,11 +376,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job, operation) (
-                                            rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_objstore_bucket_operation_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         /
                                           sum by (namespace, job, operation) (
-                                            rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_objstore_bucket_operations_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -411,7 +415,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, operation, le) (
                                         rate(
-                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -429,7 +433,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, operation, le) (
                                         rate(
-                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -447,7 +451,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, operation, le) (
                                         rate(
-                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_objstore_bucket_operation_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -478,7 +482,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job) (
-                                      rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{namespace}}'
         "3_1":
@@ -508,11 +512,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job) (
-                                            rate(thanos_bucket_store_block_load_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_bucket_store_block_load_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         /
                                           sum by (namespace, job) (
-                                            rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_bucket_store_block_loads_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -544,7 +548,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, operation) (
-                                      rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{operation}} {{namespace}}'
         "3_3":
@@ -574,11 +578,11 @@ spec:
                                 query: |4-
                                       (
                                           sum by (namespace, job) (
-                                            rate(thanos_bucket_store_block_drop_failures_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_bucket_store_block_drop_failures_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                         /
                                           sum by (namespace, job) (
-                                            rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[5m])
+                                            rate(thanos_bucket_store_block_drops_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                           )
                                       )
                                     *
@@ -610,7 +614,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, item_type) (
-                                      rate(thanos_store_index_cache_requests_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_store_index_cache_requests_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
         "4_1":
@@ -639,7 +643,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, item_type) (
-                                      rate(thanos_store_index_cache_hits_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_store_index_cache_hits_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
         "4_2":
@@ -668,7 +672,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, item_type) (
-                                      rate(thanos_store_index_cache_items_added_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_store_index_cache_items_added_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
         "4_3":
@@ -697,7 +701,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     sum by (namespace, job, item_type) (
-                                      rate(thanos_store_index_cache_items_evicted_total{job=~"$job",namespace="$namespace"}[5m])
+                                      rate(thanos_store_index_cache_items_evicted_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                     )
                                 seriesNameFormat: '{{job}} {{item_type}} {{namespace}}'
         "5_0":
@@ -726,11 +730,11 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job) (
-                                        rate(thanos_bucket_store_series_blocks_queried_sum{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_series_blocks_queried_sum{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     /
                                       sum by (namespace, job) (
-                                        rate(thanos_bucket_store_series_blocks_queried_count{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_series_blocks_queried_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                 seriesNameFormat: mean {{job}} {{namespace}}
                     - kind: TimeSeriesQuery
@@ -745,7 +749,9 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -761,7 +767,9 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -777,7 +785,9 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_series_blocks_queried_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -807,12 +817,14 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job, data_type) (
-                                        rate(thanos_bucket_store_series_data_size_fetched_bytes_sum{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_series_data_size_fetched_bytes_sum{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     /
                                       sum by (namespace, job, data_type) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_fetched_bytes_count{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_fetched_bytes_count{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: mean {{job}} {{data_type}} {{namespace}}
@@ -829,7 +841,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, data_type, le) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -847,7 +859,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, data_type, le) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -865,7 +877,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, data_type, le) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_fetched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -896,12 +908,14 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job, data_type) (
-                                        rate(thanos_bucket_store_series_data_size_touched_bytes_sum{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_series_data_size_touched_bytes_sum{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     /
                                       sum by (namespace, job, data_type) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_touched_bytes_count{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_touched_bytes_count{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                 seriesNameFormat: mean {{job}} {{data_type}} {{namespace}}
@@ -918,7 +932,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, data_type, le) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -936,7 +950,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, data_type, le) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -954,7 +968,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, data_type, le) (
                                         rate(
-                                          thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_data_size_touched_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -985,11 +999,11 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job) (
-                                        rate(thanos_bucket_store_series_result_series_sum{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_series_result_series_sum{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     /
                                       sum by (namespace, job) (
-                                        rate(thanos_bucket_store_series_result_series_count{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_series_result_series_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                 seriesNameFormat: mean {{job}} {{namespace}}
                     - kind: TimeSeriesQuery
@@ -1004,7 +1018,7 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -1020,7 +1034,7 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -1036,7 +1050,7 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_series_result_series_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     )
                                 seriesNameFormat: p99 {{job}} {{namespace}}
@@ -1069,7 +1083,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1087,7 +1101,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1105,7 +1119,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_get_all_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1139,7 +1153,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1157,7 +1171,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1175,7 +1189,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_merge_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1209,7 +1223,7 @@ spec:
                                       0.5,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1227,7 +1241,7 @@ spec:
                                       0.9,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1245,7 +1259,7 @@ spec:
                                       0.99,
                                       sum by (namespace, job, le) (
                                         rate(
-                                          thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[5m]
+                                          thanos_bucket_store_series_gate_duration_seconds_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
                                         )
                                       )
                                     )
@@ -1276,11 +1290,11 @@ spec:
                                     name: prometheus-datasource
                                 query: |4-
                                       sum by (namespace, job) (
-                                        rate(thanos_bucket_store_sent_chunk_size_bytes_sum{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_sent_chunk_size_bytes_sum{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                     /
                                       sum by (namespace, job) (
-                                        rate(thanos_bucket_store_sent_chunk_size_bytes_count{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(thanos_bucket_store_sent_chunk_size_bytes_count{job=~"$job",namespace="$namespace"}[$__rate_interval])
                                       )
                                 seriesNameFormat: mean {{job}} {{namespace}}
                     - kind: TimeSeriesQuery
@@ -1295,7 +1309,9 @@ spec:
                                     histogram_quantile(
                                       0.5,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p50 {{job}} {{namespace}}
@@ -1311,7 +1327,9 @@ spec:
                                     histogram_quantile(
                                       0.9,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p90 {{job}} {{namespace}}
@@ -1327,7 +1345,9 @@ spec:
                                     histogram_quantile(
                                       0.99,
                                       sum by (namespace, job, le) (
-                                        rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[5m])
+                                        rate(
+                                          thanos_bucket_store_sent_chunk_size_bytes_bucket{job=~"$job",namespace="$namespace"}[$__rate_interval]
+                                        )
                                       )
                                     )
                                 seriesNameFormat: p99 {{job}} {{namespace}}

--- a/pkg/panels/alertmanager/alertmanager.go
+++ b/pkg/panels/alertmanager/alertmanager.go
@@ -74,7 +74,7 @@ func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(alertmanager_alerts_received_total{job=~'$job'}[5m])) by (job,instance)",
+					"sum(rate(alertmanager_alerts_received_total{job=~'$job'}[$__rate_interval])) by (job,instance)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -84,7 +84,7 @@ func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(alertmanager_alerts_invalid_total{job=~'$job'}[5m])) by (job,instance)",
+					"sum(rate(alertmanager_alerts_invalid_total{job=~'$job'}[$__rate_interval])) by (job,instance)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -128,7 +128,7 @@ func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(alertmanager_notifications_total{job=~'$job', integration=~'$integration'}[5m])) by (integration, instance)",
+					"sum(rate(alertmanager_notifications_total{job=~'$job', integration=~'$integration'}[$__rate_interval])) by (integration, instance)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -138,7 +138,7 @@ func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(alertmanager_notifications_failed_total{job=~'$job', integration=~'$integration'}[5m])) by (integration, instance)",
+					"sum(rate(alertmanager_notifications_failed_total{job=~'$job', integration=~'$integration'}[$__rate_interval])) by (integration, instance)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -186,7 +186,7 @@ func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum(rate(alertmanager_notification_latency_seconds_bucket{job=~'$job', integration=~'$integration'}[5m])) by (le,integration,instance))",
+					"histogram_quantile(0.99, sum(rate(alertmanager_notification_latency_seconds_bucket{job=~'$job', integration=~'$integration'}[$__rate_interval])) by (le,integration,instance))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -196,7 +196,7 @@ func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum(rate(alertmanager_notification_latency_seconds_bucket{job=~'$job', integration=~'$integration'}[5m])) by (le,integration,instance))",
+					"histogram_quantile(0.50, sum(rate(alertmanager_notification_latency_seconds_bucket{job=~'$job', integration=~'$integration'}[$__rate_interval])) by (le,integration,instance))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -206,7 +206,7 @@ func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(alertmanager_notification_latency_seconds_sum{job=~'$job', integration=~'$integration'}[5m])) by (integration,instance) / sum(rate(alertmanager_notification_latency_seconds_count{job=~'$job', integration=~'$integration'}[5m])) by (integration,instance)",
+					"sum(rate(alertmanager_notification_latency_seconds_sum{job=~'$job', integration=~'$integration'}[$__rate_interval])) by (integration,instance) / sum(rate(alertmanager_notification_latency_seconds_count{job=~'$job', integration=~'$integration'}[$__rate_interval])) by (integration,instance)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/gostats/gostats.go
+++ b/pkg/panels/gostats/gostats.go
@@ -57,7 +57,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(go_memstats_alloc_bytes_total[5m])",
+					"rate(go_memstats_alloc_bytes_total[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -67,7 +67,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(go_memstats_heap_alloc_bytes[5m])",
+					"rate(go_memstats_heap_alloc_bytes[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/kubernetes/cluster.go
+++ b/pkg/panels/kubernetes/cluster.go
@@ -318,7 +318,7 @@ func ClusterCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+					"sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -327,7 +327,7 @@ func ClusterCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+					"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -336,7 +336,7 @@ func ClusterCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+					"sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -345,7 +345,7 @@ func ClusterCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+					"sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -354,7 +354,7 @@ func ClusterCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+					"sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -363,7 +363,7 @@ func ClusterCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+					"sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -429,7 +429,7 @@ func ClusterCurrentStorageIO(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(namespace) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+					"sum by(namespace) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -438,7 +438,7 @@ func ClusterCurrentStorageIO(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(namespace) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+					"sum by(namespace) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -447,7 +447,7 @@ func ClusterCurrentStorageIO(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(namespace) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+					"sum by(namespace) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -456,7 +456,7 @@ func ClusterCurrentStorageIO(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(namespace) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+					"sum by(namespace) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -465,7 +465,7 @@ func ClusterCurrentStorageIO(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(namespace) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+					"sum by(namespace) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -474,7 +474,7 @@ func ClusterCurrentStorageIO(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(namespace) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+					"sum by(namespace) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/kubernetes/namespace.go
+++ b/pkg/panels/kubernetes/namespace.go
@@ -304,7 +304,7 @@ func NamespaceCurrentNetworkUsage(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+					"sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -313,7 +313,7 @@ func NamespaceCurrentNetworkUsage(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+					"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -322,7 +322,7 @@ func NamespaceCurrentNetworkUsage(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+					"sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -331,7 +331,7 @@ func NamespaceCurrentNetworkUsage(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+					"sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -340,7 +340,7 @@ func NamespaceCurrentNetworkUsage(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+					"sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -349,7 +349,7 @@ func NamespaceCurrentNetworkUsage(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+					"sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -415,7 +415,7 @@ func NamespaceCurrentStorageIO(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(pod) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+					"sum by(pod) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -424,7 +424,7 @@ func NamespaceCurrentStorageIO(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(pod) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+					"sum by(pod) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -433,7 +433,7 @@ func NamespaceCurrentStorageIO(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(pod) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+					"sum by(pod) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -442,7 +442,7 @@ func NamespaceCurrentStorageIO(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(pod) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+					"sum by(pod) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -451,7 +451,7 @@ func NamespaceCurrentStorageIO(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(pod) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+					"sum by(pod) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -460,7 +460,7 @@ func NamespaceCurrentStorageIO(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(pod) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+					"sum by(pod) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/kubernetes/networking.go
+++ b/pkg/panels/kubernetes/networking.go
@@ -22,7 +22,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -36,7 +36,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (namespace) (\n    rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (namespace) (\n    rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -50,7 +50,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+						"sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -64,7 +64,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -78,7 +78,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -92,7 +92,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (pod) (\n    rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (pod) (\n    rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -106,7 +106,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -120,7 +120,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"sort_desc(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -134,7 +134,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(irate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -148,7 +148,7 @@ func KubernetesReceiveBandwidth(granularity, datasourceName string, labelMatcher
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -197,7 +197,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -211,7 +211,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (namespace) (\n    rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (namespace) (\n    rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace!=\"\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -225,7 +225,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+						"sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -239,7 +239,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -253,7 +253,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -267,7 +267,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (pod) (\n    rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (pod) (\n    rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -281,7 +281,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -295,7 +295,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"sort_desc(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -309,7 +309,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -323,7 +323,7 @@ func KubernetesTransmitBandwidth(granularity, datasourceName string, labelMatche
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -373,7 +373,7 @@ func KubernetesAvgContainerBandwidthTransmitted(granularity, datasourceName stri
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"avg(irate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"avg(irate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -388,7 +388,7 @@ func KubernetesAvgContainerBandwidthTransmitted(granularity, datasourceName stri
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(avg(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(avg(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -403,7 +403,7 @@ func KubernetesAvgContainerBandwidthTransmitted(granularity, datasourceName stri
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(avg(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(avg(rate(container_network_transmit_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -418,7 +418,7 @@ func KubernetesAvgContainerBandwidthTransmitted(granularity, datasourceName stri
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(avg(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(avg(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -467,7 +467,7 @@ func KubernetesAvgContainerBandwidthReceived(granularity, datasourceName string,
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"avg(irate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"avg(irate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -482,7 +482,7 @@ func KubernetesAvgContainerBandwidthReceived(granularity, datasourceName string,
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(avg(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(avg(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -497,7 +497,7 @@ func KubernetesAvgContainerBandwidthReceived(granularity, datasourceName string,
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(avg(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(avg(rate(container_network_receive_bytes_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -512,7 +512,7 @@ func KubernetesAvgContainerBandwidthReceived(granularity, datasourceName string,
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(avg(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(avg(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -560,7 +560,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"sum(irate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -574,7 +574,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+						"sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -588,7 +588,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -602,7 +602,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -616,7 +616,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -630,7 +630,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (namespace) (\n    rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (namespace) (\n    rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace!=\"\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -644,7 +644,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (pod) (\n    rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (pod) (\n    rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -658,7 +658,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -672,7 +672,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"sort_desc(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -686,7 +686,7 @@ func KubernetesReceivedPackets(granularity, datasourceName string, labelMatchers
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_receive_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -734,7 +734,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"sum(irate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -748,7 +748,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+						"sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -762,7 +762,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -776,7 +776,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -790,7 +790,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -804,7 +804,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (namespace) (\n    rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (namespace) (\n    rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -818,7 +818,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (pod) (\n    rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (pod) (\n    rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -832,7 +832,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -846,7 +846,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"sort_desc(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -860,7 +860,7 @@ func KubernetesReceivedPacketsDropped(granularity, datasourceName string, labelM
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_receive_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -908,7 +908,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"sum(irate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -922,7 +922,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+						"sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -936,7 +936,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -950,7 +950,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -964,7 +964,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -978,7 +978,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (namespace) (\n    rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace!=\"\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (namespace) (\n    rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace!=\"\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -992,7 +992,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (pod) (\n    rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (pod) (\n    rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1006,7 +1006,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1020,7 +1020,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"sort_desc(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1034,7 +1034,7 @@ func KubernetesTransmittedPackets(granularity, datasourceName string, labelMatch
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_transmit_packets_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1082,7 +1082,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[5m])) by (namespace)",
+						"sum(irate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=~\".+\"}[$__rate_interval])) by (namespace)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1096,7 +1096,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[5m])) by (pod)",
+						"sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1110,7 +1110,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1124,7 +1124,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1138,7 +1138,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1152,7 +1152,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (namespace) (\n    rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (namespace) (\n    rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace!=\"\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1166,7 +1166,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by (pod) (\n    rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
+						"sum by (pod) (\n    rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n  * on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n)\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1180,7 +1180,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[5m])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
+						"sort_desc(sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=\"$namespace\"}[$__rate_interval])\n* on (cluster,namespace,pod) group_left ()\n    topk by (cluster,namespace,pod) (\n      1,\n      max by (cluster,namespace,pod) (kube_pod_info{host_network=\"false\"})\n    )\n* on (cluster,namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=\"$namespace\", workload=~\".+\", workload_type=~\"$type\"}) by (workload))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1194,7 +1194,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sort_desc(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+						"sort_desc(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\",namespace=~\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -1208,7 +1208,7 @@ func KubernetesTransmittedPacketsDropped(granularity, datasourceName string, lab
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[5m])) by (pod)",
+						"sum(rate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\",namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])) by (pod)",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/kubernetes/pod.go
+++ b/pkg/panels/kubernetes/pod.go
@@ -37,7 +37,7 @@ func PodCPUThrottling(datasourceName string, labelMatchers ...promql.LabelMatche
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(increase(container_cpu_cfs_throttled_periods_total{"+GetCAdvisorMatcher()+", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{"+GetCAdvisorMatcher()+", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[5m])) by (container)",
+					"sum(increase(container_cpu_cfs_throttled_periods_total{"+GetCAdvisorMatcher()+", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container) /sum(increase(container_cpu_cfs_periods_total{"+GetCAdvisorMatcher()+", namespace=\"$namespace\", pod=\"$pod\", container!=\"\", cluster=\"$cluster\"}[$__rate_interval])) by (container)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -340,7 +340,7 @@ func PodCurrentStorageIO(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(container) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+					"sum by(container) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -349,7 +349,7 @@ func PodCurrentStorageIO(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(container) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+					"sum by(container) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+",device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -358,7 +358,7 @@ func PodCurrentStorageIO(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(container) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+					"sum by(container) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -367,7 +367,7 @@ func PodCurrentStorageIO(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(container) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+					"sum by(container) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -376,7 +376,7 @@ func PodCurrentStorageIO(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(container) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+					"sum by(container) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -385,7 +385,7 @@ func PodCurrentStorageIO(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by(container) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+					"sum by(container) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/kubernetes/storage.go
+++ b/pkg/panels/kubernetes/storage.go
@@ -23,7 +23,7 @@ func KubernetesIOPS(granularity, datasourceName string, labelMatchers ...promql.
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"ceil(sum by(namespace) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m])))",
+						"ceil(sum by(namespace) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval])))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -38,7 +38,7 @@ func KubernetesIOPS(granularity, datasourceName string, labelMatchers ...promql.
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])))",
+						"ceil(sum by(pod) (rate(container_fs_reads_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -53,7 +53,7 @@ func KubernetesIOPS(granularity, datasourceName string, labelMatchers ...promql.
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"ceil(sum by(pod) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
+						"ceil(sum by(pod) (rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\",namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -63,7 +63,7 @@ func KubernetesIOPS(granularity, datasourceName string, labelMatchers ...promql.
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"ceil(sum by(pod) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m])))",
+						"ceil(sum by(pod) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval])))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -78,7 +78,7 @@ func KubernetesIOPS(granularity, datasourceName string, labelMatchers ...promql.
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"ceil(sum by(container) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m])))",
+						"ceil(sum by(container) (rate(container_fs_reads_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval])))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -127,7 +127,7 @@ func KubernetesThroughput(granularity, datasourceName string, labelMatchers ...p
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by(namespace) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[5m]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[5m]))",
+						"sum by(namespace) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace!=\"\"}[$__rate_interval]))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -142,7 +142,7 @@ func KubernetesThroughput(granularity, datasourceName string, labelMatchers ...p
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]) + rate(container_fs_writes_bytes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[5m]))",
+						"sum by(pod) (rate(container_fs_reads_bytes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{container!=\"\", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval]))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -157,7 +157,7 @@ func KubernetesThroughput(granularity, datasourceName string, labelMatchers ...p
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by(pod) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
+						"sum by(pod) (rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -167,7 +167,7 @@ func KubernetesThroughput(granularity, datasourceName string, labelMatchers ...p
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by(pod) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[5m]))",
+						"sum by(pod) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", device=~\"(/dev.+)|mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dm-.+|dasd.+\", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=~\"$pod\"}[$__rate_interval]))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),
@@ -182,7 +182,7 @@ func KubernetesThroughput(granularity, datasourceName string, labelMatchers ...p
 			panel.AddQuery(
 				query.PromQL(
 					promql.SetLabelMatchers(
-						"sum by(container) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[5m]))",
+						"sum by(container) (rate(container_fs_reads_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]) + rate(container_fs_writes_bytes_total{"+GetCAdvisorMatcher()+", container!=\"\", cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}[$__rate_interval]))",
 						labelMatchers,
 					),
 					dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/kubernetes/workload.go
+++ b/pkg/panels/kubernetes/workload.go
@@ -262,7 +262,7 @@ func WorkloadCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+					"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -271,7 +271,7 @@ func WorkloadCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+					"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -280,7 +280,7 @@ func WorkloadCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+					"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -289,7 +289,7 @@ func WorkloadCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+					"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -298,7 +298,7 @@ func WorkloadCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+					"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -307,7 +307,7 @@ func WorkloadCurrentNetworkUsage(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
+					"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload=~\"$workload\", workload_type=~\"$type\"}) by (pod))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/kubernetes/workload_namespace.go
+++ b/pkg/panels/kubernetes/workload_namespace.go
@@ -300,7 +300,7 @@ func WorkloadNamespaceCurrentNetworkUsage(datasourceName string, labelMatchers .
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+					"(sum(rate(container_network_receive_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -309,7 +309,7 @@ func WorkloadNamespaceCurrentNetworkUsage(datasourceName string, labelMatchers .
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+					"(sum(rate(container_network_transmit_bytes_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -318,7 +318,7 @@ func WorkloadNamespaceCurrentNetworkUsage(datasourceName string, labelMatchers .
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+					"(sum(rate(container_network_receive_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -327,7 +327,7 @@ func WorkloadNamespaceCurrentNetworkUsage(datasourceName string, labelMatchers .
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+					"(sum(rate(container_network_transmit_packets_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -336,7 +336,7 @@ func WorkloadNamespaceCurrentNetworkUsage(datasourceName string, labelMatchers .
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+					"(sum(rate(container_network_receive_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -345,7 +345,7 @@ func WorkloadNamespaceCurrentNetworkUsage(datasourceName string, labelMatchers .
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[5m])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
+					"(sum(rate(container_network_transmit_packets_dropped_total{"+GetCAdvisorMatcher()+", cluster=\"$cluster\", namespace=\"$namespace\"}[$__rate_interval])\n* on (namespace,pod)\ngroup_left(workload,workload_type) namespace_workload_pod:kube_pod_owner:relabel{cluster=\"$cluster\", namespace=\"$namespace\", workload_type=~\"$type\"}) by (workload))\n",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/node_exporter/node_exporter.go
+++ b/pkg/panels/node_exporter/node_exporter.go
@@ -46,7 +46,7 @@ func NodeCPUUsagePercentage(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"((1 - sum without (mode) (rate(node_cpu_seconds_total{job='node', mode=~'idle|iowait|steal', instance='$instance'}[5m]))) / ignoring(cpu) group_left count without (cpu, mode) (node_cpu_seconds_total{job='node', mode='idle', instance='$instance'}))",
+					"((1 - sum without (mode) (rate(node_cpu_seconds_total{job='node', mode=~'idle|iowait|steal', instance='$instance'}[$__rate_interval]))) / ignoring(cpu) group_left count without (cpu, mode) (node_cpu_seconds_total{job='node', mode='idle', instance='$instance'}))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -660,7 +660,7 @@ func NodeDiskIOBytes(datasourceName string, labelMatchers ...promql.LabelMatcher
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(node_disk_read_bytes_total{job='node', instance='$instance',device!=''}[5m])",
+					"rate(node_disk_read_bytes_total{job='node', instance='$instance',device!=''}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -670,7 +670,7 @@ func NodeDiskIOBytes(datasourceName string, labelMatchers ...promql.LabelMatcher
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(node_disk_io_time_seconds_total{job='node', instance='$instance',device!=''}[5m])",
+					"rate(node_disk_io_time_seconds_total{job='node', instance='$instance',device!=''}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -706,7 +706,7 @@ func NodeDiskIOSeconds(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(node_disk_io_time_seconds_total{job='node', instance='$instance',device!=''}[5m])",
+					"rate(node_disk_io_time_seconds_total{job='node', instance='$instance',device!=''}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -750,7 +750,7 @@ func NodeNetworkReceivedBytes(datasourceName string, labelMatchers ...promql.Lab
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(node_network_receive_bytes_total{job='node', instance='$instance',device!='lo'}[5m])",
+					"rate(node_network_receive_bytes_total{job='node', instance='$instance',device!='lo'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -794,7 +794,7 @@ func NodeNetworkTransmitedBytes(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(node_network_transmit_bytes_total{job='node', instance='$instance',device!='lo'}[5m])",
+					"rate(node_network_transmit_bytes_total{job='node', instance='$instance',device!='lo'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/perses/perses.go
+++ b/pkg/panels/perses/perses.go
@@ -72,7 +72,7 @@ func HTTPRequestsLatencyPanel(datasourceName string, labelMatchers ...promql.Lab
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (handler, method) (rate(perses_http_request_duration_second_sum{job=~'$job', instance=~'$instance'}[5m])) / sum by (handler, method) (rate(perses_http_request_duration_second_count{job=~'$job', instance=~'$instance'}[5m]))",
+					"sum by (handler, method) (rate(perses_http_request_duration_second_sum{job=~'$job', instance=~'$instance'}[$__rate_interval])) / sum by (handler, method) (rate(perses_http_request_duration_second_count{job=~'$job', instance=~'$instance'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -99,7 +99,7 @@ func HTTPRequestsRatePanel(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (handler, code) (rate(perses_http_request_total{job=~'$job', instance=~'$instance'}[5m]))",
+					"sum by (handler, code) (rate(perses_http_request_total{job=~'$job', instance=~'$instance'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -126,7 +126,7 @@ func HTTPErrorsRatePanel(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (handler, code) (rate(perses_http_request_total{job=~'$job', instance=~'$instance', code=~'4..|5..'}[5m]))",
+					"sum by (handler, code) (rate(perses_http_request_total{job=~'$job', instance=~'$instance', code=~'4..|5..'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -154,7 +154,7 @@ func CPUUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) panel
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(process_cpu_seconds_total{job=~'$job', instance=~'$instance'}[5m])",
+					"rate(process_cpu_seconds_total{job=~'$job', instance=~'$instance'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/prometheus/prometheus.go
+++ b/pkg/panels/prometheus/prometheus.go
@@ -86,7 +86,7 @@ func PrometheusTargetSync(datasourceName string, labelMatchers ...promql.LabelMa
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("sum(rate(prometheus_target_sync_length_seconds_sum{job=~'$job',instance=~'$instance'}[5m])) by (job, scrape_job, instance)", labelMatchers),
+				promql.SetLabelMatchers("sum(rate(prometheus_target_sync_length_seconds_sum{job=~'$job',instance=~'$instance'}[$__rate_interval])) by (job, scrape_job, instance)", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("{{job}} - {{instance}} - Metrics"),
 			),
@@ -159,7 +159,7 @@ func PrometheusAverageScrapeIntervalDuration(datasourceName string, labelMatcher
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("rate(prometheus_target_interval_length_seconds_sum{job=~'$job',instance=~'$instance'}[5m]) / rate(prometheus_target_interval_length_seconds_count{job=~'$job',instance=~'$instance'}[5m])",
+				promql.SetLabelMatchers("rate(prometheus_target_interval_length_seconds_sum{job=~'$job',instance=~'$instance'}[$__rate_interval]) / rate(prometheus_target_interval_length_seconds_count{job=~'$job',instance=~'$instance'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -192,35 +192,35 @@ func PrometheusScrapeFailures(datasourceName string, labelMatchers ...promql.Lab
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_exceeded_body_size_limit_total{job=~'$job',instance=~'$instance'}[1m]))", labelMatchers),
+				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_exceeded_body_size_limit_total{job=~'$job',instance=~'$instance'}[$__rate_interval]))", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("exceeded body size limit: {{job}} - {{instance}} - Metrics"),
 			),
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_exceeded_sample_limit_total{job=~'$job',instance=~'$instance'}[1m]))", labelMatchers),
+				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_exceeded_sample_limit_total{job=~'$job',instance=~'$instance'}[$__rate_interval]))", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("exceeded sample limit: {{job}} - {{instance}} - Metrics"),
 			),
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=~'$job',instance=~'$instance'}[1m]))", labelMatchers),
+				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_sample_duplicate_timestamp_total{job=~'$job',instance=~'$instance'}[$__rate_interval]))", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("duplicate timestamp: {{job}} - {{instance}} - Metrics"),
 			),
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_sample_out_of_bounds_total{job=~'$job',instance=~'$instance'}[1m]))", labelMatchers),
+				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_sample_out_of_bounds_total{job=~'$job',instance=~'$instance'}[$__rate_interval]))", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("out of bounds: {{job}} - {{instance}} - Metrics"),
 			),
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_sample_out_of_order_total{job=~'$job',instance=~'$instance'}[1m]))", labelMatchers),
+				promql.SetLabelMatchers("sum by (job, instance) (rate(prometheus_target_scrapes_sample_out_of_order_total{job=~'$job',instance=~'$instance'}[$__rate_interval]))", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("out of order: {{job}} - {{instance}} - Metrics"),
 			),
@@ -247,7 +247,7 @@ func PrometheusAppendedSamples(datasourceName string, labelMatchers ...promql.La
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("rate(prometheus_tsdb_head_samples_appended_total{job=~'$job',instance=~'$instance'}[5m])", labelMatchers),
+				promql.SetLabelMatchers("rate(prometheus_tsdb_head_samples_appended_total{job=~'$job',instance=~'$instance'}[$__rate_interval])", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("{{job}} - {{instance}} - {{remote_name}} - {{url}}"),
 			),
@@ -333,7 +333,7 @@ func PrometheusQueryRate(datasourceName string, labelMatchers ...promql.LabelMat
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("rate(prometheus_engine_query_duration_seconds_count{job=~'$job',instance=~'$instance',slice='inner_eval'}[5m])", labelMatchers),
+				promql.SetLabelMatchers("rate(prometheus_engine_query_duration_seconds_count{job=~'$job',instance=~'$instance',slice='inner_eval'}[$__rate_interval])", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("{{job}} - {{instance}} - Query Rate"),
 			),
@@ -424,7 +424,7 @@ func PrometheusRemoteStorageTimestampLag(datasourceName string, labelMatchers ..
 // - Rate of lag between storage and queue timestamps
 // - 5-minute rate changes per target
 func PrometheusRemoteStorageRateLag(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
-	return panelgroup.AddPanel("Rate[5m]",
+	return panelgroup.AddPanel("Rate",
 		panel.Description("Shows rate metrics over 5 minute intervals"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -435,7 +435,7 @@ func PrometheusRemoteStorageRateLag(datasourceName string, labelMatchers ...prom
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"clamp_min(rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~'$instance'}[5m])  - ignoring (remote_name, url) group_right(instance) rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~'$instance', url='$url'}[5m]), 0)",
+					"clamp_min(rate(prometheus_remote_storage_highest_timestamp_in_seconds{instance=~'$instance'}[$__rate_interval])  - ignoring (remote_name, url) group_right(instance) rate(prometheus_remote_storage_queue_highest_sent_timestamp_seconds{instance=~'$instance', url='$url'}[$__rate_interval]), 0)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -464,7 +464,7 @@ func PrometheusRemoteStorageRateLag(datasourceName string, labelMatchers ...prom
 // Returns:
 //   - panelgroup.Option: The configured panel option.
 func PrometheusRemoteStorageSampleRate(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
-	return panelgroup.AddPanel("Rate, in vs. succeeded or dropped [5m]",
+	return panelgroup.AddPanel("Rate, in vs. succeeded or dropped",
 		panel.Description("Shows rate of samples in remote storage"),
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -475,7 +475,7 @@ func PrometheusRemoteStorageSampleRate(datasourceName string, labelMatchers ...p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(prometheus_remote_storage_samples_in_total{instance=~'$instance'}[5m]) - ignoring(remote_name, url) group_right(instance) (rate(prometheus_remote_storage_succeeded_samples_total{instance=~'$instance', url='$url'}[5m]) or rate(prometheus_remote_storage_samples_total{instance=~'$instance', url='$url'}[5m])) - (rate(prometheus_remote_storage_dropped_samples_total{instance=~'$instance', url='$url'}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{instance=~'$instance', url='$url'}[5m]))",
+					"rate(prometheus_remote_storage_samples_in_total{instance=~'$instance'}[$__rate_interval]) - ignoring(remote_name, url) group_right(instance) (rate(prometheus_remote_storage_succeeded_samples_total{instance=~'$instance', url='$url'}[$__rate_interval]) or rate(prometheus_remote_storage_samples_total{instance=~'$instance', url='$url'}[$__rate_interval])) - (rate(prometheus_remote_storage_dropped_samples_total{instance=~'$instance', url='$url'}[$__rate_interval]) or rate(prometheus_remote_storage_samples_dropped_total{instance=~'$instance', url='$url'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -756,7 +756,7 @@ func PrometheusRemoteStorageDroppedSamplesRate(datasourceName string, labelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(prometheus_remote_storage_dropped_samples_total{instance=~'$instance', url='$url'}[5m]) or rate(prometheus_remote_storage_samples_dropped_total{instance=~'$instance', url='$url'}[5m])",
+					"rate(prometheus_remote_storage_dropped_samples_total{instance=~'$instance', url='$url'}[$__rate_interval]) or rate(prometheus_remote_storage_samples_dropped_total{instance=~'$instance', url='$url'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -788,7 +788,7 @@ func PrometheusRemoteStorageFailedSamplesRate(datasourceName string, labelMatche
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(prometheus_remote_storage_failed_samples_total{instance=~'$instance', url='$url'}[5m]) or rate(prometheus_remote_storage_samples_failed_total{instance=~'$instance', url='$url'}[5m])",
+					"rate(prometheus_remote_storage_failed_samples_total{instance=~'$instance', url='$url'}[$__rate_interval]) or rate(prometheus_remote_storage_samples_failed_total{instance=~'$instance', url='$url'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -820,7 +820,7 @@ func PrometheusRemoteStorageRetriedSamplesRate(datasourceName string, labelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(prometheus_remote_storage_retried_samples_total{instance=~'$instance', url=~'$url'}[5m]) or rate(prometheus_remote_storage_samples_retried_total{instance=~'$instance', url=~'$url'}[5m])",
+					"rate(prometheus_remote_storage_retried_samples_total{instance=~'$instance', url=~'$url'}[$__rate_interval]) or rate(prometheus_remote_storage_samples_retried_total{instance=~'$instance', url=~'$url'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -851,7 +851,7 @@ func PrometheusRemoteStorageEnqueueRetriesRate(datasourceName string, labelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"rate(prometheus_remote_storage_enqueue_retries_total{instance=~'$instance', url=~'$url'}[5m])",
+					"rate(prometheus_remote_storage_enqueue_retries_total{instance=~'$instance', url=~'$url'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/thanos/common.go
+++ b/pkg/panels/thanos/common.go
@@ -29,7 +29,7 @@ func BucketOperationRate(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -56,7 +56,7 @@ func BucketOperationErrors(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_failures_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace='$namespace', job=~'$job'}[5m]))) * 100",
+					"(sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operation_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job, operation) (rate(thanos_objstore_bucket_operations_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -83,7 +83,7 @@ func BucketOperationDurations(datasourceName string, labelMatchers ...promql.Lab
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -93,7 +93,7 @@ func BucketOperationDurations(datasourceName string, labelMatchers ...promql.Lab
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -103,7 +103,7 @@ func BucketOperationDurations(datasourceName string, labelMatchers ...promql.Lab
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, operation, le) (rate(thanos_objstore_bucket_operation_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -130,7 +130,7 @@ func ReadGRPCUnaryRate(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[5m]))",
+					"sum by (namespace, job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -157,7 +157,7 @@ func ReadGRPCUnaryErrors(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[5m])) / ignoring (grpc_code) group_left() sum by (namespace, job) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[5m]))",
+					"sum by (namespace, job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$__rate_interval])) / ignoring (grpc_code) group_left() sum by (namespace, job) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -184,7 +184,7 @@ func ReadGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -194,7 +194,7 @@ func ReadGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -204,7 +204,7 @@ func ReadGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method!=\"RemoteWrite\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -231,7 +231,7 @@ func ReadGRPCStreamRate(datasourceName string, labelMatchers ...promql.LabelMatc
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[5m]))",
+					"sum by (namespace, job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -258,7 +258,7 @@ func ReadGRPCStreamErrors(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[5m])) / ignoring (grpc_code) group_left() sum by (namespace, job) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[5m]))",
+					"sum by (namespace, job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[$__rate_interval])) / ignoring (grpc_code) group_left() sum by (namespace, job) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -285,7 +285,7 @@ func ReadGPRCStreamDurations(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -295,7 +295,7 @@ func ReadGPRCStreamDurations(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -305,7 +305,7 @@ func ReadGPRCStreamDurations(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"server_stream\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/thanos/thanos_compact.go
+++ b/pkg/panels/thanos/thanos_compact.go
@@ -29,7 +29,7 @@ func GroupCompactionRate(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, resolution) (rate(thanos_compact_group_compactions_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, resolution) (rate(thanos_compact_group_compactions_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -56,7 +56,7 @@ func GroupCompactionErrors(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job) (rate(thanos_compact_group_compactions_failures_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_compact_group_compactions_total{namespace='$namespace', job=~'$job'}[5m]))) * 100",
+					"(sum by (namespace, job) (rate(thanos_compact_group_compactions_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_compact_group_compactions_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -83,7 +83,7 @@ func DownsampleRate(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, resolution) (rate(thanos_compact_downsample_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, resolution) (rate(thanos_compact_downsample_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -110,7 +110,7 @@ func DownsampleErrors(datasourceName string, labelMatchers ...promql.LabelMatche
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job) (rate(thanos_compact_downsample_failed_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_compact_downsample_total{namespace='$namespace', job=~'$job'}[5m]))) * 100",
+					"(sum by (namespace, job) (rate(thanos_compact_downsample_failed_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_compact_downsample_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -137,7 +137,7 @@ func DownsampleDurations(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, resolution, le) (rate(thanos_compact_downsample_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, resolution, le) (rate(thanos_compact_downsample_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -147,7 +147,7 @@ func DownsampleDurations(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, resolution, le) (rate(thanos_compact_downsample_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, resolution, le) (rate(thanos_compact_downsample_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -157,7 +157,7 @@ func DownsampleDurations(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, resolution, le) (rate(thanos_compact_downsample_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, resolution, le) (rate(thanos_compact_downsample_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -184,7 +184,7 @@ func SyncMetaRate(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -211,7 +211,7 @@ func SyncMetaErrors(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job) (rate(thanos_blocks_meta_sync_failures_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace='$namespace', job=~'$job'}[5m]))) * 100",
+					"(sum by (namespace, job) (rate(thanos_blocks_meta_sync_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_blocks_meta_syncs_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -238,7 +238,7 @@ func SyncMetaDurations(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -248,7 +248,7 @@ func SyncMetaDurations(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -258,7 +258,7 @@ func SyncMetaDurations(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_blocks_meta_sync_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -285,7 +285,7 @@ func DeletionRate(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_compact_blocks_cleaned_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_compact_blocks_cleaned_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -312,7 +312,7 @@ func DeletionErrors(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_compact_block_cleanup_failures_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_compact_block_cleanup_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -339,7 +339,7 @@ func MarkingRate(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_compact_blocks_marked_total{namespace='$namespace', job=~'$job', marker=\"deletion-mark.json\"}[5m]))",
+					"sum by (namespace, job) (rate(thanos_compact_blocks_marked_total{namespace='$namespace', job=~'$job', marker=\"deletion-mark.json\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -366,7 +366,7 @@ func GarbageCollectionRate(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -393,7 +393,7 @@ func GarbageCollectionErrors(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job) (rate(thanos_compact_garbage_collection_failures_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace='$namespace', job=~'$job'}[5m]))) * 100",
+					"(sum by (namespace, job) (rate(thanos_compact_garbage_collection_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_compact_garbage_collection_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -420,7 +420,7 @@ func GarbageCollectionDurations(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -430,7 +430,7 @@ func GarbageCollectionDurations(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -440,7 +440,7 @@ func GarbageCollectionDurations(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_compact_garbage_collection_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/thanos/thanos_query.go
+++ b/pkg/panels/thanos/thanos_query.go
@@ -29,7 +29,7 @@ func InstantQueryRequestRate(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query\"}[5m]))",
+					"sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -56,7 +56,7 @@ func InstantQueryRequestErrors(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query\",code=~\"5..\"}[5m])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query\"}[5m]))) * 100",
+					"(sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query\",code=~\"5..\"}[$__rate_interval])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query\"}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -83,7 +83,7 @@ func InstantQueryRequestDurations(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query\"}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -93,7 +93,7 @@ func InstantQueryRequestDurations(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query\"}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -103,7 +103,7 @@ func InstantQueryRequestDurations(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query\"}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -130,7 +130,7 @@ func RangeQueryRequestRate(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query_range\"}[5m]))",
+					"sum by (namespace,  job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query_range\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -157,7 +157,7 @@ func RangeQueryRequestErrors(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query_range\",code=~\"5..\"}[5m])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query_range\"}[5m]))) * 100",
+					"(sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query_range\",code=~\"5..\"}[$__rate_interval])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query_range\"}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -184,7 +184,7 @@ func RangeQueryRequestDurations(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query_range\"}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query_range\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -194,7 +194,7 @@ func RangeQueryRequestDurations(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query_range\"}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query_range\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -204,7 +204,7 @@ func RangeQueryRequestDurations(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query_range\"}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query_range\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -226,7 +226,7 @@ func QueryConcurrency(datasourceName string, labelMatchers ...promql.LabelMatche
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"max_over_time(thanos_query_concurrent_gate_queries_max{namespace='$namespace', job=~'$job'}[5m]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight{namespace='$namespace', job=~'$job'}[5m])",
+					"max_over_time(thanos_query_concurrent_gate_queries_max{namespace='$namespace', job=~'$job'}[$__rate_interval]) - avg_over_time(thanos_query_concurrent_gate_queries_in_flight{namespace='$namespace', job=~'$job'}[$__rate_interval])",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -253,7 +253,7 @@ func DNSLookups(datasourceName string, labelMatchers ...promql.LabelMatcher) pan
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -280,7 +280,7 @@ func DNSLookupsErrors(datasourceName string, labelMatchers ...promql.LabelMatche
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_query_store_apis_dns_failures_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_query_store_apis_dns_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/thanos/thanos_query_frontend.go
+++ b/pkg/panels/thanos/thanos_query_frontend.go
@@ -29,7 +29,7 @@ func QueryFrontendRequestRate(datasourceName string, labelMatchers ...promql.Lab
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[5m]))",
+					"sum by (namespace, job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -56,7 +56,7 @@ func QueryFrontendQueryRate(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, handler, code) (rate(thanos_query_frontend_queries_total{namespace='$namespace', job=~'$job', op=\"query_range\"}[5m]))",
+					"sum by (namespace, job, handler, code) (rate(thanos_query_frontend_queries_total{namespace='$namespace', job=~'$job', op=\"query_range\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -83,7 +83,7 @@ func QueryFrontendErrors(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					`sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler="query-frontend",code=~"5.."}[5m])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler="query-frontend"}[5m]))`,
+					`sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler="query-frontend",code=~"5.."}[$__rate_interval])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler="query-frontend"}[$__rate_interval]))`,
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -110,7 +110,7 @@ func QueryFrontendDurations(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -120,7 +120,7 @@ func QueryFrontendDurations(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -130,7 +130,7 @@ func QueryFrontendDurations(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"query-frontend\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -157,7 +157,7 @@ func QueryFrontendCacheRequestRate(datasourceName string, labelMatchers ...promq
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, tripperware) (rate(cortex_cache_request_duration_seconds_count{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, tripperware) (rate(cortex_cache_request_duration_seconds_count{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -184,7 +184,7 @@ func QueryFrontendCacheHitRate(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, tripperware) (rate(cortex_cache_hits_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, tripperware) (rate(cortex_cache_hits_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -211,7 +211,7 @@ func QueryFrontendCacheMissRate(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, tripperware) (rate(querier_cache_misses_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, tripperware) (rate(querier_cache_misses_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -238,7 +238,7 @@ func QueryFrontendFetchedKeyRate(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, tripperware) (rate(cortex_cache_fetched_keys_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, tripperware) (rate(cortex_cache_fetched_keys_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/thanos/thanos_receive.go
+++ b/pkg/panels/thanos/thanos_receive.go
@@ -29,7 +29,7 @@ func RemoteWriteRequestRate(datasourceName string, labelMatchers ...promql.Label
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("sum by (namespace, job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\"}[5m]))",
+				promql.SetLabelMatchers("sum by (namespace, job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -56,7 +56,7 @@ func RemoteWriteRequestErrors(datasourceName string, labelMatchers ...promql.Lab
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\",code=~\"5..\"}[5m])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\"}[5m]))) * 100",
+					"(sum by (namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\",code=~\"5..\"}[$__rate_interval])) / ignoring (code) group_left() sum by (namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\"}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -83,7 +83,7 @@ func RemoteWriteRequestDurations(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"receive\"}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"receive\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -93,7 +93,7 @@ func RemoteWriteRequestDurations(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"receive\"}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"receive\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -103,7 +103,7 @@ func RemoteWriteRequestDurations(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"receive\"}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(http_request_duration_seconds_bucket{namespace='$namespace', job=~'$job', handler=\"receive\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -130,7 +130,7 @@ func TenantedRemoteWriteRequestRate(datasourceName string, labelMatchers ...prom
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (tenant, job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\"}[5m]))",
+					"sum by (tenant, job, handler, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -157,7 +157,7 @@ func TenantedRemoteWriteRequestErrors(datasourceName string, labelMatchers ...pr
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (tenant, namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\", code!~\"2..\", tenant=~'$tenant'}[5m])) / ignoring (code) group_left() sum by (tenant, namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\", tenant=~'$tenant'}[5m]))) * 100",
+					"(sum by (tenant, namespace, job, code) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\", code!~\"2..\", tenant=~'$tenant'}[$__rate_interval])) / ignoring (code) group_left() sum by (tenant, namespace, job) (rate(http_requests_total{namespace='$namespace', job=~'$job', handler=\"receive\", tenant=~'$tenant'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -184,7 +184,7 @@ func TenantedRemoteWriteRequestDurations(datasourceName string, labelMatchers ..
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, tenant) (rate(http_request_duration_seconds_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\"}[5m])) / sum by (namespace, job, tenant) (http_request_duration_seconds_count{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\"})",
+					"sum by (namespace, job, tenant) (rate(http_request_duration_seconds_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\"}[$__rate_interval])) / sum by (namespace, job, tenant) (http_request_duration_seconds_count{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\"})",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -211,7 +211,7 @@ func AvgRemoteWriteRequestSize(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, tenant) (rate(http_request_size_bytes_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code=~\"2..\"}[5m])) / sum by (namespace, job, tenant) (rate(http_request_size_bytes_count{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code=~\"2..\"}[5m]))",
+					"sum by (namespace, job, tenant) (rate(http_request_size_bytes_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code=~\"2..\"}[$__rate_interval])) / sum by (namespace, job, tenant) (rate(http_request_size_bytes_count{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code=~\"2..\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -238,7 +238,7 @@ func AvgFailedRemoteWriteRequestSize(datasourceName string, labelMatchers ...pro
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, tenant) (rate(http_request_size_bytes_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code!~\"2..\"}[5m])) / sum by (namespace, job, tenant) (rate(http_request_size_bytes_count{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code!~\"2..\"}[5m]))",
+					"sum by (namespace, job, tenant) (rate(http_request_size_bytes_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code!~\"2..\"}[$__rate_interval])) / sum by (namespace, job, tenant) (rate(http_request_size_bytes_count{namespace='$namespace', job=~'$job', tenant=~'$tenant', handler=\"receive\", code!~\"2..\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -287,7 +287,7 @@ func RemoteWriteSeriesRate(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(thanos_receive_write_timeseries_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code=~\"2..\"}[5m])) by (namespace, job, tenant)",
+					"sum(rate(thanos_receive_write_timeseries_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code=~\"2..\"}[$__rate_interval])) by (namespace, job, tenant)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -309,7 +309,7 @@ func RemoteWriteSeriesNotWrittenRate(datasourceName string, labelMatchers ...pro
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(thanos_receive_write_timeseries_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code!~\"2..\"}[5m])) by (namespace, job, tenant)",
+					"sum(rate(thanos_receive_write_timeseries_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code!~\"2..\"}[$__rate_interval])) by (namespace, job, tenant)",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -331,7 +331,7 @@ func RemoteWriteSamplesRate(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(thanos_receive_write_samples_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code=~\"2..\"}[5m])) by (namespace, job, tenant) ",
+					"sum(rate(thanos_receive_write_samples_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code=~\"2..\"}[$__rate_interval])) by (namespace, job, tenant) ",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -353,7 +353,7 @@ func RemoteWriteSamplesNotWrittenRate(datasourceName string, labelMatchers ...pr
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum(rate(thanos_receive_write_samples_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code!~\"2..\"}[5m])) by (namespace, job, tenant) ",
+					"sum(rate(thanos_receive_write_samples_sum{namespace='$namespace', job=~'$job', tenant=~'$tenant', code!~\"2..\"}[$__rate_interval])) by (namespace, job, tenant) ",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -380,7 +380,7 @@ func RemoteWriteReplicationRate(datasourceName string, labelMatchers ...promql.L
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_receive_replications_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_receive_replications_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -407,7 +407,7 @@ func RemoteWriteReplicationErrorRate(datasourceName string, labelMatchers ...pro
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_receive_replications_total{namespace='$namespace', job=~'$job', result=\"error\"}[5m]))",
+					"sum by (namespace, job) (rate(thanos_receive_replications_total{namespace='$namespace', job=~'$job', result=\"error\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -434,7 +434,7 @@ func RemoteWriteForwardRate(datasourceName string, labelMatchers ...promql.Label
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -461,7 +461,7 @@ func RemoteWriteForwardErrorRate(datasourceName string, labelMatchers ...promql.
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace='$namespace', job=~'$job', result=\"error\"}[5m]))",
+					"sum by (namespace, job) (rate(thanos_receive_forward_requests_total{namespace='$namespace', job=~'$job', result=\"error\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -488,7 +488,7 @@ func WriteGRPCUnaryRate(datasourceName string, labelMatchers ...promql.LabelMatc
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[5m]))",
+					"sum by (namespace, job, grpc_method, grpc_code) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -515,7 +515,7 @@ func WriteGRPCUnaryErrors(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[5m])) / ignoring (grpc_code) group_left() sum by (namespace, job) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[5m]))",
+					"sum by (namespace, job, grpc_code) (rate(grpc_server_handled_total{grpc_code=~\"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss\",namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$__rate_interval])) / ignoring (grpc_code) group_left() sum by (namespace, job) (rate(grpc_server_handled_total{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -542,7 +542,7 @@ func WriteGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -552,7 +552,7 @@ func WriteGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -562,7 +562,7 @@ func WriteGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Labe
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(grpc_server_handling_seconds_bucket{namespace='$namespace', job=~'$job', grpc_type=\"unary\", grpc_method=\"RemoteWrite\"}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -583,7 +583,7 @@ func ReceiveAppendedSampleRate(datasourceName string, labelMatchers ...promql.La
 		),
 		panel.AddQuery(
 			query.PromQL(
-				promql.SetLabelMatchers("rate(prometheus_tsdb_head_samples_appended_total{job=~'$job',namespace=~'$namespace'}[5m])", labelMatchers),
+				promql.SetLabelMatchers("rate(prometheus_tsdb_head_samples_appended_total{job=~'$job',namespace=~'$namespace'}[$__rate_interval])", labelMatchers),
 				dashboards.AddQueryDataSource(datasourceName),
 				query.SeriesNameFormat("{{job}} - {{namespace}}"),
 			),

--- a/pkg/panels/thanos/thanos_ruler.go
+++ b/pkg/panels/thanos/thanos_ruler.go
@@ -29,7 +29,7 @@ func RuleEvaluationRate(datasourceName string, labelMatchers ...promql.LabelMatc
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, rule_group, strategy) (rate(prometheus_rule_evaluations_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, rule_group, strategy) (rate(prometheus_rule_evaluations_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -56,7 +56,7 @@ func RuleEvaluationFailureRate(datasourceName string, labelMatchers ...promql.La
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, rule_group, strategy) (rate(prometheus_rule_evaluation_failures_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, rule_group, strategy) (rate(prometheus_rule_evaluation_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -83,7 +83,7 @@ func RuleGroupEvaluationsMissRate(datasourceName string, labelMatchers ...promql
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, rule_group, strategy) (rate(prometheus_rule_group_iterations_missed_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, rule_group, strategy) (rate(prometheus_rule_group_iterations_missed_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -141,7 +141,7 @@ func AlertsDroppedRate(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_dropped_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_dropped_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -168,7 +168,7 @@ func AlertsSentRate(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, alertmanager) (rate(thanos_alert_sender_alerts_sent_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -195,7 +195,7 @@ func AlertSendingErrors(datasourceName string, labelMatchers ...promql.LabelMatc
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					`sum by (namespace, job) (rate(thanos_alert_sender_errors_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_alert_sender_alerts_sent_total{namespace='$namespace', job=~'$job'}[5m]))`,
+					`sum by (namespace, job) (rate(thanos_alert_sender_errors_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_alert_sender_alerts_sent_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))`,
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -222,7 +222,7 @@ func AlertSendingDurations(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -232,7 +232,7 @@ func AlertSendingDurations(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -242,7 +242,7 @@ func AlertSendingDurations(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_alert_sender_latency_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -269,7 +269,7 @@ func AlertQueuePushedRate(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_alert_queue_alerts_pushed_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_alert_queue_alerts_pushed_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -296,7 +296,7 @@ func AlertQueuePoppedRate(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_alert_queue_alerts_popped_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_alert_queue_alerts_popped_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -323,7 +323,7 @@ func DroppedRatio(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					`sum by (namespace, job) (rate(thanos_alert_queue_alerts_dropped_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_alert_queue_alerts_pushed_total{namespace='$namespace', job=~'$job'}[5m]))`,
+					`sum by (namespace, job) (rate(thanos_alert_queue_alerts_dropped_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_alert_queue_alerts_pushed_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))`,
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/panels/thanos/thanos_store.go
+++ b/pkg/panels/thanos/thanos_store.go
@@ -29,7 +29,7 @@ func BlockLoadRate(datasourceName string, labelMatchers ...promql.LabelMatcher) 
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -56,7 +56,7 @@ func BlockLoadErrors(datasourceName string, labelMatchers ...promql.LabelMatcher
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job) (rate(thanos_bucket_store_block_load_failures_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace='$namespace', job=~'$job'}[5m]))) * 100",
+					"(sum by (namespace, job) (rate(thanos_bucket_store_block_load_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_bucket_store_block_loads_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -83,7 +83,7 @@ func BlockDropRate(datasourceName string, labelMatchers ...promql.LabelMatcher) 
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, operation) (rate(thanos_bucket_store_block_drops_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, operation) (rate(thanos_bucket_store_block_drops_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -110,7 +110,7 @@ func BlockDropErrors(datasourceName string, labelMatchers ...promql.LabelMatcher
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"(sum by (namespace, job) (rate(thanos_bucket_store_block_drop_failures_total{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_bucket_store_block_drops_total{namespace='$namespace', job=~'$job'}[5m]))) * 100",
+					"(sum by (namespace, job) (rate(thanos_bucket_store_block_drop_failures_total{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_bucket_store_block_drops_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -137,7 +137,7 @@ func CacheRequestRate(datasourceName string, labelMatchers ...promql.LabelMatche
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_requests_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_requests_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -164,7 +164,7 @@ func CacheHitRate(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_hits_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_hits_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -191,7 +191,7 @@ func CacheItemsAddRate(datasourceName string, labelMatchers ...promql.LabelMatch
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_added_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_added_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -218,7 +218,7 @@ func CacheItemsEvictRate(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_evicted_total{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, item_type) (rate(thanos_store_index_cache_items_evicted_total{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -245,7 +245,7 @@ func BlocksQueried(datasourceName string, labelMatchers ...promql.LabelMatcher) 
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_sum{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_count{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_sum{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_blocks_queried_count{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -255,7 +255,7 @@ func BlocksQueried(datasourceName string, labelMatchers ...promql.LabelMatcher) 
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_blocks_queried_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_blocks_queried_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -265,7 +265,7 @@ func BlocksQueried(datasourceName string, labelMatchers ...promql.LabelMatcher) 
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_blocks_queried_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_blocks_queried_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -275,7 +275,7 @@ func BlocksQueried(datasourceName string, labelMatchers ...promql.LabelMatcher) 
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_blocks_queried_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_blocks_queried_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -302,7 +302,7 @@ func DataFetched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_fetched_bytes_sum{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_fetched_bytes_count{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_fetched_bytes_sum{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_fetched_bytes_count{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -312,7 +312,7 @@ func DataFetched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_fetched_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_fetched_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -322,7 +322,7 @@ func DataFetched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_fetched_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_fetched_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -332,7 +332,7 @@ func DataFetched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_fetched_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_fetched_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -359,7 +359,7 @@ func DataTouched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_touched_bytes_sum{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_touched_bytes_count{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_touched_bytes_sum{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job, data_type) (rate(thanos_bucket_store_series_data_size_touched_bytes_count{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -369,7 +369,7 @@ func DataTouched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_touched_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_touched_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -379,7 +379,7 @@ func DataTouched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_touched_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_touched_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -389,7 +389,7 @@ func DataTouched(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_touched_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, data_type, le) (rate(thanos_bucket_store_series_data_size_touched_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -416,7 +416,7 @@ func ResultSeries(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_sum{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_count{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_sum{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_bucket_store_series_result_series_count{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -426,7 +426,7 @@ func ResultSeries(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_result_series_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_result_series_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -436,7 +436,7 @@ func ResultSeries(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_result_series_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_result_series_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -446,7 +446,7 @@ func ResultSeries(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_result_series_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_result_series_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -473,7 +473,7 @@ func GetAllSeriesDurations(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -483,7 +483,7 @@ func GetAllSeriesDurations(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -493,7 +493,7 @@ func GetAllSeriesDurations(datasourceName string, labelMatchers ...promql.LabelM
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_get_all_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -520,7 +520,7 @@ func MergeDurations(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -530,7 +530,7 @@ func MergeDurations(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -540,7 +540,7 @@ func MergeDurations(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_merge_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -567,7 +567,7 @@ func GateWaitingDurations(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -577,7 +577,7 @@ func GateWaitingDurations(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -587,7 +587,7 @@ func GateWaitingDurations(datasourceName string, labelMatchers ...promql.LabelMa
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_series_gate_duration_seconds_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -614,7 +614,7 @@ func StoreSentChunkSizes(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_sum{namespace='$namespace', job=~'$job'}[5m])) / sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_count{namespace='$namespace', job=~'$job'}[5m]))",
+					"sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_sum{namespace='$namespace', job=~'$job'}[$__rate_interval])) / sum by (namespace, job) (rate(thanos_bucket_store_sent_chunk_size_bytes_count{namespace='$namespace', job=~'$job'}[$__rate_interval]))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -624,7 +624,7 @@ func StoreSentChunkSizes(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.50, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -634,7 +634,7 @@ func StoreSentChunkSizes(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.90, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
@@ -644,7 +644,7 @@ func StoreSentChunkSizes(datasourceName string, labelMatchers ...promql.LabelMat
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace='$namespace', job=~'$job'}[5m])))",
+					"histogram_quantile(0.99, sum by (namespace, job, le) (rate(thanos_bucket_store_sent_chunk_size_bytes_bucket{namespace='$namespace', job=~'$job'}[$__rate_interval])))",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),

--- a/pkg/promql/promql.go
+++ b/pkg/promql/promql.go
@@ -2,10 +2,85 @@ package promql
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/prometheus/prometheus/model/labels"
 	"github.com/prometheus/prometheus/promql/parser"
 )
+
+type PersesVarProcessor struct {
+	Replacements map[string]string
+	SortedKeys   []string
+}
+
+// NewPersesVarProcessor creates a new PersesVarProcessor which will help replace/restore Perses variables in a query
+// to make it compatible with PromQL parser.
+// Sort of a hack, by modifying the query in place with random values
+func NewPersesVarProcessor() *PersesVarProcessor {
+	// Keep the variables in this map super unique, so that we can replace them safely.
+	replacements := map[string]string{
+		"$__rate_interval": "2d20h8m7s",
+		"$__interval":      "2d20h8m8s",
+		"$__interval_ms":   "7d19h59m27s",
+		"$__dashboard":     "CHEESECAKE",
+		"$__project":       "CHEESECAKE-DEV",
+		"$__from":          "1715222400000.000",
+		"$__to":            "1715222400000.000",
+		"$__range":         "2d20h8m9s",
+		"$__range_s":       "1h2m17s",
+		"$__range_ms":      "3737373",
+	}
+
+	var sortedKeys []string
+	for key := range replacements {
+		sortedKeys = append(sortedKeys, key)
+	}
+	sort.Slice(sortedKeys, func(i, j int) bool {
+		return len(sortedKeys[i]) > len(sortedKeys[j])
+	})
+
+	return &PersesVarProcessor{
+		Replacements: replacements,
+		SortedKeys:   sortedKeys,
+	}
+}
+
+func (p *PersesVarProcessor) Replace(query string) (string, map[string]string) {
+	original := make(map[string]string)
+	for _, name := range p.SortedKeys {
+		if strings.Contains(query, name) {
+			placeholder := p.Replacements[name]
+			original[name] = placeholder
+			query = strings.ReplaceAll(query, name, placeholder)
+		}
+	}
+	return query, original
+}
+
+func (p *PersesVarProcessor) Restore(query string, original map[string]string) string {
+	// Build a list of varName/placeholder pairs
+	type pair struct {
+		varName     string
+		placeholder string
+	}
+	var pairs []pair
+	for varName, placeholder := range original {
+		pairs = append(pairs, pair{varName, placeholder})
+	}
+
+	// Sort by placeholder length descending
+	sort.Slice(pairs, func(i, j int) bool {
+		return len(pairs[i].placeholder) > len(pairs[j].placeholder)
+	})
+
+	// Replace each placeholder with the original var
+	for _, p := range pairs {
+		query = strings.ReplaceAll(query, p.placeholder, p.varName)
+	}
+
+	return query
+}
 
 type LabelMatcher struct {
 	Name  string
@@ -14,21 +89,26 @@ type LabelMatcher struct {
 }
 
 func SetLabelMatchers(query string, labelMatchers []LabelMatcher) string {
+	processor := NewPersesVarProcessor()
+
 	for _, l := range labelMatchers {
-		query = LabelsSetPromQL(query, l.Type, l.Name, l.Value)
+		query = LabelsSetPromQL(query, l.Type, l.Name, l.Value, processor)
 	}
 	return query
 }
 
-func LabelsSetPromQL(query, labelMatchType, name, value string) string {
-	expr, err := parser.ParseExpr(query)
+func LabelsSetPromQL(query, labelMatchType, name, value string, processor *PersesVarProcessor) string {
+	modifiedQuery, originalVars := processor.Replace(query)
+	expr, err := parser.ParseExpr(modifiedQuery)
 	if err != nil {
-		fmt.Println("Error parsing query:", err)
+		fmt.Println("Error parsing query:", err, modifiedQuery)
 		return ""
 	}
 
 	if name == "" || value == "" {
-		return expr.Pretty(0)
+		// Get the modified query and restore Perses variables
+		result := expr.Pretty(0)
+		return processor.Restore(result, originalVars)
 	}
 
 	var matchType labels.MatchType
@@ -42,6 +122,7 @@ func LabelsSetPromQL(query, labelMatchType, name, value string) string {
 	case parser.ItemType(parser.NEQ_REGEX).String():
 		matchType = labels.MatchNotRegexp
 	default:
+		fmt.Println("Invalid match type:", labelMatchType)
 		return ""
 	}
 
@@ -65,5 +146,8 @@ func LabelsSetPromQL(query, labelMatchType, name, value string) string {
 		}
 		return nil
 	})
-	return expr.Pretty(0)
+
+	// Get the modified query and restore Perses variables
+	result := expr.Pretty(0)
+	return processor.Restore(result, originalVars)
 }

--- a/pkg/promql/promql_test.go
+++ b/pkg/promql/promql_test.go
@@ -1,0 +1,121 @@
+package promql
+
+import (
+	"testing"
+)
+
+func TestSetLabelMatchers(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		labelMatchers []LabelMatcher
+		want          string
+	}{
+		{
+			name:  "simple metric query",
+			query: "metric{job=\"test\"}",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "metric{instance=\"localhost:9090\",job=\"test\"}",
+		},
+		{
+			name:  "query with rate and interval variable",
+			query: "rate(metric{job=\"test\"}[$__rate_interval])",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "rate(metric{instance=\"localhost:9090\",job=\"test\"}[$__rate_interval])",
+		},
+		{
+			name:  "query with multiple variables",
+			query: "metric{job=\"test\"}[$__rate_interval] offset $__range",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "metric{instance=\"localhost:9090\",job=\"test\"}[$__rate_interval] offset $__range",
+		},
+		{
+			name:  "query with regex match",
+			query: "metric{job=~\"test.*\"}",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost.*", Type: "=~"},
+			},
+			want: "metric{instance=~\"localhost.*\",job=~\"test.*\"}",
+		},
+		{
+			name:  "query with negative match",
+			query: "metric{job!=\"test\"}",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "!="},
+			},
+			want: "metric{instance!=\"localhost:9090\",job!=\"test\"}",
+		},
+		{
+			name:  "query with multiple label matchers",
+			query: "metric{job=\"test\"}",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+				{Name: "env", Value: "prod", Type: "="},
+			},
+			want: "metric{env=\"prod\",instance=\"localhost:9090\",job=\"test\"}",
+		},
+		{
+			name:  "query with complex expression and variables",
+			query: "sum(rate(metric{job=\"test\"}[$__rate_interval])) by (instance) / 3",
+			labelMatchers: []LabelMatcher{
+				{Name: "env", Value: "prod", Type: "="},
+			},
+			want: "sum by (instance) (rate(metric{env=\"prod\",job=\"test\"}[$__rate_interval])) / 3",
+		},
+		{
+			name:  "query with all Perses variables",
+			query: "metric{job=\"test\"}[$__interval] offset $__range",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "metric{instance=\"localhost:9090\",job=\"test\"}[$__interval] offset $__range",
+		},
+		{
+			name:  "query with dashboard and project variables",
+			query: "metric{job=\"test\",dashboard=\"$__dashboard\",project=\"$__project\"}",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "metric{dashboard=\"$__dashboard\",instance=\"localhost:9090\",job=\"test\",project=\"$__project\"}",
+		},
+		{
+			name:  "query with time range variables",
+			query: "metric{job=\"test\"}[$__interval] @ $__from",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "metric{instance=\"localhost:9090\",job=\"test\"}[$__interval] @ $__from",
+		},
+		{
+			name:  "query with ms variables",
+			query: "metric{job=\"test\"}[$__interval_ms]",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "metric{instance=\"localhost:9090\",job=\"test\"}[$__interval_ms]",
+		},
+		{
+			name:  "query with range variables",
+			query: "metric{job=\"test\"}[$__range_s]",
+			labelMatchers: []LabelMatcher{
+				{Name: "instance", Value: "localhost:9090", Type: "="},
+			},
+			want: "metric{instance=\"localhost:9090\",job=\"test\"}[$__range_s]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SetLabelMatchers(tt.query, tt.labelMatchers)
+			if got != tt.want {
+				t.Errorf("SetLabelMatchers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit modifies `SetLabelMatchers` to internally modify queries and replace Perses default variables with unique placeholders.

It will then pass the modified query to promQL parser (without errors as the placeholders are valid promQL), and eventually restore the Perses variables once new label matchers have been added.

This commit also replaces all the range selectors in dashboard queries with `$__rate_interval`.

Sort of a hacky approach, but it works. Alternatives would be to build queries from strings internally.