### PR TITLE
ENHANCMENT(perses-dashboard): 🎨 Add visual configuration for time series panels in Perses

### DIFF
--- a/examples/dashboards/operator/perses/perses-overview.yaml
+++ b/examples/dashboards/operator/perses/perses-overview.yaml
@@ -143,6 +143,12 @@ spec:
             legend:
               mode: table
               position: right
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: milliseconds
@@ -176,6 +182,12 @@ spec:
             legend:
               mode: table
               position: right
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: decimal
@@ -205,6 +217,12 @@ spec:
             legend:
               mode: table
               position: right
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: decimal
@@ -330,6 +348,12 @@ spec:
               position: bottom
               values:
               - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: percent
@@ -426,6 +450,12 @@ spec:
               position: bottom
               values:
               - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: decimal
@@ -464,6 +494,12 @@ spec:
               position: bottom
               values:
               - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: decimal

--- a/examples/dashboards/perses/perses/perses-overview.yaml
+++ b/examples/dashboards/perses/perses/perses-overview.yaml
@@ -95,6 +95,12 @@ spec:
                         yAxis:
                             format:
                                 unit: milliseconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -128,6 +134,12 @@ spec:
                         yAxis:
                             format:
                                 unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -157,6 +169,12 @@ spec:
                         yAxis:
                             format:
                                 unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -282,6 +300,12 @@ spec:
                         yAxis:
                             format:
                                 unit: percent
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -378,6 +402,12 @@ spec:
                         yAxis:
                             format:
                                 unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -416,6 +446,12 @@ spec:
                         yAxis:
                             format:
                                 unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:

--- a/pkg/dashboards/perses/perses_overview.go
+++ b/pkg/dashboards/perses/perses_overview.go
@@ -55,9 +55,9 @@ func withPersesOverviewStatsGroup(datasource string, clusterLabelMatcher promql.
 
 func withPersesAPiRequestGroup(datasource string, clusterLabelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("API Requests", panelgroup.PanelsPerLine(2),
-		perses.HTTPRequestsLatencyPanel(datasource, clusterLabelMatcher),
 		perses.HTTPRequestsRatePanel(datasource, clusterLabelMatcher),
-		perses.HTTPErrorsRatePanel(datasource, clusterLabelMatcher),
+		perses.HTTPErrorPercentagePanel(datasource, clusterLabelMatcher),
+		perses.HTTPRequestsLatencyPanel(datasource, clusterLabelMatcher),
 	)
 }
 

--- a/pkg/panels/perses/perses.go
+++ b/pkg/panels/perses/perses.go
@@ -107,6 +107,7 @@ func HTTPRequestsRatePanel(datasourceName string, labelMatchers ...promql.LabelM
 				ConnectNulls: false,
 				LineWidth:    0.25,
 				AreaOpacity:  0.5,
+				Stack:        timeSeriesPanel.AllStack,
 				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
@@ -123,35 +124,43 @@ func HTTPRequestsRatePanel(datasourceName string, labelMatchers ...promql.LabelM
 	)
 }
 
-func HTTPErrorsRatePanel(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
-	return panelgroup.AddPanel("HTTP Errors Rate",
-		panel.Description("Displays the rate of all HTTP errors over a 5-minute window."),
+func HTTPErrorPercentagePanel(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel(
+		"HTTP Errors Percentage",
+		panel.Description("Displays the percentage of HTTP errors over total requests."),
 		timeSeriesPanel.Chart(
-			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
-				Format: &common.Format{
-					Unit: string(common.DecimalUnit),
+			timeSeriesPanel.WithYAxis(
+				timeSeriesPanel.YAxis{
+					Format: &common.Format{
+						Unit: string(common.PercentDecimalUnit),
+					},
 				},
-			}),
-			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
-				Position: timeSeriesPanel.RightPosition,
-				Mode:     timeSeriesPanel.TableMode,
-			}),
-			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
-				Display:      timeSeriesPanel.LineDisplay,
-				ConnectNulls: false,
-				LineWidth:    0.25,
-				AreaOpacity:  0.5,
-				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
-			}),
+			),
+			timeSeriesPanel.WithLegend(
+				timeSeriesPanel.Legend{
+					Position: timeSeriesPanel.RightPosition,
+					Mode:     timeSeriesPanel.TableMode,
+				},
+			),
+			timeSeriesPanel.WithVisual(
+				timeSeriesPanel.Visual{
+					Display:      timeSeriesPanel.LineDisplay,
+					ConnectNulls: false,
+					LineWidth:    0.25,
+					AreaOpacity:  0.5,
+					Stack:        timeSeriesPanel.AllStack,
+					Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+				},
+			),
 		),
 		panel.AddQuery(
 			query.PromQL(
 				promql.SetLabelMatchers(
-					"sum by (handler, code) (rate(perses_http_request_total{job=~'$job', instance=~'$instance', code=~'4..|5..'}[$__rate_interval]))",
+					"(sum by (handler, code) (rate(perses_http_request_total{job=~'$job', instance=~'$instance', code=~'4..|5..'}[$__rate_interval]))) / ignoring(code) group_left() (sum by (handler) (rate(perses_http_request_total{job=~'$job', instance=~'$instance'}[$__rate_interval]))) * 100",
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{handler}} {{method}} {{code}}"),
+				query.SeriesNameFormat("{{handler}} {{code}}"),
 			),
 		),
 	)

--- a/pkg/panels/perses/perses.go
+++ b/pkg/panels/perses/perses.go
@@ -68,6 +68,13 @@ func HTTPRequestsLatencyPanel(datasourceName string, labelMatchers ...promql.Lab
 				Position: timeSeriesPanel.RightPosition,
 				Mode:     timeSeriesPanel.TableMode,
 			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
 		),
 		panel.AddQuery(
 			query.PromQL(
@@ -94,6 +101,13 @@ func HTTPRequestsRatePanel(datasourceName string, labelMatchers ...promql.LabelM
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.RightPosition,
 				Mode:     timeSeriesPanel.TableMode,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(
@@ -122,6 +136,13 @@ func HTTPErrorsRatePanel(datasourceName string, labelMatchers ...promql.LabelMat
 				Position: timeSeriesPanel.RightPosition,
 				Mode:     timeSeriesPanel.TableMode,
 			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
 		),
 		panel.AddQuery(
 			query.PromQL(
@@ -144,11 +165,19 @@ func CPUUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) panel
 				Format: &common.Format{
 					Unit: string(common.PercentUnit),
 				},
-			}),
+			},
+			),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
 				Values:   []common.Calculation{common.LastCalculation},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(
@@ -177,6 +206,13 @@ func FileDescriptors(datasourceName string, labelMatchers ...promql.LabelMatcher
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
 				Values:   []common.Calculation{common.LastCalculation},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(
@@ -215,6 +251,13 @@ func PluginSchemaLoadAttempts(datasourceName string, labelMatchers ...promql.Lab
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
 				Values:   []common.Calculation{common.LastCalculation},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(


### PR DESCRIPTION
* Introduced visual settings for time series panels, including:
  - `display`: line
  - `lineWidth`: 0.25
  - `areaOpacity`: 0.5
  - `palette`: auto mode
* Enhanced the overall appearance and readability of the dashboard metrics.

cc: @saswatamcode
## Screenshot
![image](https://github.com/user-attachments/assets/d5383708-4c8f-4708-80fe-a8f9860c423d)


Signed-off-by: Akshay Iyyadurai Balasundaram <akshay.iyyadurai.balasundaram@sap.com>