### PR TITLE
Perses dashboard follow-up

### DIFF
--- a/examples/dashboards/operator/perses/perses-overview.yaml
+++ b/examples/dashboards/operator/perses/perses-overview.yaml
@@ -135,6 +135,84 @@ spec:
       kind: Panel
       spec:
         display:
+          description: Displays the rate of HTTP requests over a 5-minute window.
+          name: HTTP Requests Rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: right
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+              stack: all
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (handler, code) (
+                    rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
+                  )
+                seriesNameFormat: '{{handler}} {{method}} {{code}}'
+    "1_1":
+      kind: Panel
+      spec:
+        display:
+          description: Displays the percentage of HTTP errors over total requests.
+          name: HTTP Errors Percentage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: right
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+              stack: all
+            yAxis:
+              format:
+                unit: percent-decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                      (
+                        sum by (handler, code) (
+                          rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[$__rate_interval])
+                        )
+                      )
+                    / ignoring (code) group_left ()
+                      (sum by (handler) (rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])))
+                  *
+                    100
+                seriesNameFormat: '{{handler}} {{code}}'
+    "1_2":
+      kind: Panel
+      spec:
+        display:
           description: Displays the latency of HTTP requests over a 5-minute window.
           name: HTTP Requests Latency
         plugin:
@@ -170,76 +248,6 @@ spec:
                       rate(perses_http_request_duration_second_count{instance=~"$instance",job=~"$job"}[$__rate_interval])
                     )
                 seriesNameFormat: '{{handler}} {{method}}'
-    "1_1":
-      kind: Panel
-      spec:
-        display:
-          description: Displays the rate of HTTP requests over a 5-minute window.
-          name: HTTP Requests Rate
-        plugin:
-          kind: TimeSeriesChart
-          spec:
-            legend:
-              mode: table
-              position: right
-            visual:
-              areaOpacity: 0.5
-              display: line
-              lineWidth: 0.25
-              palette:
-                mode: auto
-            yAxis:
-              format:
-                unit: decimal
-        queries:
-        - kind: TimeSeriesQuery
-          spec:
-            plugin:
-              kind: PrometheusTimeSeriesQuery
-              spec:
-                datasource:
-                  kind: PrometheusDatasource
-                  name: prometheus-datasource
-                query: |-
-                  sum by (handler, code) (
-                    rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
-                  )
-                seriesNameFormat: '{{handler}} {{method}} {{code}}'
-    "1_2":
-      kind: Panel
-      spec:
-        display:
-          description: Displays the rate of all HTTP errors over a 5-minute window.
-          name: HTTP Errors Rate
-        plugin:
-          kind: TimeSeriesChart
-          spec:
-            legend:
-              mode: table
-              position: right
-            visual:
-              areaOpacity: 0.5
-              display: line
-              lineWidth: 0.25
-              palette:
-                mode: auto
-            yAxis:
-              format:
-                unit: decimal
-        queries:
-        - kind: TimeSeriesQuery
-          spec:
-            plugin:
-              kind: PrometheusTimeSeriesQuery
-              spec:
-                datasource:
-                  kind: PrometheusDatasource
-                  name: prometheus-datasource
-                query: |-
-                  sum by (handler, code) (
-                    rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[$__rate_interval])
-                  )
-                seriesNameFormat: '{{handler}} {{method}} {{code}}'
     "2_0":
       kind: Panel
       spec:

--- a/examples/dashboards/perses/perses/perses-overview.yaml
+++ b/examples/dashboards/perses/perses/perses-overview.yaml
@@ -84,6 +84,84 @@ spec:
             kind: Panel
             spec:
                 display:
+                    name: HTTP Requests Rate
+                    description: Displays the rate of HTTP requests over a 5-minute window.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: right
+                            mode: table
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                            stack: all
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (handler, code) (
+                                      rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
+                                    )
+                                seriesNameFormat: '{{handler}} {{method}} {{code}}'
+        "1_1":
+            kind: Panel
+            spec:
+                display:
+                    name: HTTP Errors Percentage
+                    description: Displays the percentage of HTTP errors over total requests.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: right
+                            mode: table
+                        yAxis:
+                            format:
+                                unit: percent-decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                            stack: all
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                        (
+                                          sum by (handler, code) (
+                                            rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[$__rate_interval])
+                                          )
+                                        )
+                                      / ignoring (code) group_left ()
+                                        (sum by (handler) (rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])))
+                                    *
+                                      100
+                                seriesNameFormat: '{{handler}} {{code}}'
+        "1_2":
+            kind: Panel
+            spec:
+                display:
                     name: HTTP Requests Latency
                     description: Displays the latency of HTTP requests over a 5-minute window.
                 plugin:
@@ -119,76 +197,6 @@ spec:
                                         rate(perses_http_request_duration_second_count{instance=~"$instance",job=~"$job"}[$__rate_interval])
                                       )
                                 seriesNameFormat: '{{handler}} {{method}}'
-        "1_1":
-            kind: Panel
-            spec:
-                display:
-                    name: HTTP Requests Rate
-                    description: Displays the rate of HTTP requests over a 5-minute window.
-                plugin:
-                    kind: TimeSeriesChart
-                    spec:
-                        legend:
-                            position: right
-                            mode: table
-                        yAxis:
-                            format:
-                                unit: decimal
-                        visual:
-                            display: line
-                            lineWidth: 0.25
-                            areaOpacity: 0.5
-                            palette:
-                                mode: auto
-                queries:
-                    - kind: TimeSeriesQuery
-                      spec:
-                        plugin:
-                            kind: PrometheusTimeSeriesQuery
-                            spec:
-                                datasource:
-                                    kind: PrometheusDatasource
-                                    name: prometheus-datasource
-                                query: |-
-                                    sum by (handler, code) (
-                                      rate(perses_http_request_total{instance=~"$instance",job=~"$job"}[$__rate_interval])
-                                    )
-                                seriesNameFormat: '{{handler}} {{method}} {{code}}'
-        "1_2":
-            kind: Panel
-            spec:
-                display:
-                    name: HTTP Errors Rate
-                    description: Displays the rate of all HTTP errors over a 5-minute window.
-                plugin:
-                    kind: TimeSeriesChart
-                    spec:
-                        legend:
-                            position: right
-                            mode: table
-                        yAxis:
-                            format:
-                                unit: decimal
-                        visual:
-                            display: line
-                            lineWidth: 0.25
-                            areaOpacity: 0.5
-                            palette:
-                                mode: auto
-                queries:
-                    - kind: TimeSeriesQuery
-                      spec:
-                        plugin:
-                            kind: PrometheusTimeSeriesQuery
-                            spec:
-                                datasource:
-                                    kind: PrometheusDatasource
-                                    name: prometheus-datasource
-                                query: |-
-                                    sum by (handler, code) (
-                                      rate(perses_http_request_total{code=~"4..|5..",instance=~"$instance",job=~"$job"}[$__rate_interval])
-                                    )
-                                seriesNameFormat: '{{handler}} {{method}} {{code}}'
         "2_0":
             kind: Panel
             spec:


### PR DESCRIPTION
Follow up for https://github.com/perses/community-dashboards/pull/64

- ran `make build-dashboards`

@nicolastakashi: Do you think it makes sense to have a step in GitHub Actions PR workflow to check if the committer had executed `make build-dashboards` and if not, fail the workflow? 

Signed-off-by: Akshay Iyyadurai Balasundaram <akshay.iyyadurai.balasundaram@sap.com>