### PR TITLE
Unify CPU Usage into gostats

### DIFF
--- a/examples/dashboards/operator/kubernetes/controller-manager-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/controller-manager-overview.yaml
@@ -443,7 +443,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                seriesNameFormat: Alloc All {{pod}}
+                seriesNameFormat: Alloc All {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -453,7 +453,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                seriesNameFormat: Alloc Heap {{pod}}
+                seriesNameFormat: Alloc Heap {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -466,7 +466,7 @@ spec:
                   rate(
                     go_memstats_alloc_bytes_total{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
                   )
-                seriesNameFormat: Alloc Rate All {{pod}}
+                seriesNameFormat: Alloc Rate All {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -479,7 +479,7 @@ spec:
                   rate(
                     go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
                   )
-                seriesNameFormat: Alloc Rate Heap {{pod}}
+                seriesNameFormat: Alloc Rate Heap {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -489,7 +489,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                seriesNameFormat: Inuse Stack {{pod}}
+                seriesNameFormat: Inuse Stack {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -499,7 +499,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                seriesNameFormat: Inuse Heap {{pod}}
+                seriesNameFormat: Inuse Heap {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -509,12 +509,12 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                seriesNameFormat: Resident Memory {{pod}}
+                seriesNameFormat: Resident Memory {{instance}}
     "3_1":
       kind: Panel
       spec:
         display:
-          description: Kubelete CPU Usage
+          description: Shows the CPU usage of the component.
           name: CPU Usage
         plugin:
           kind: TimeSeriesChart
@@ -580,7 +580,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_goroutines{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                seriesNameFormat: '{{pod}}'
+                seriesNameFormat: '{{instance}}'
     "3_3":
       kind: Panel
       spec:
@@ -614,7 +614,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_gc_duration_seconds{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                seriesNameFormat: '{{quantile}} - {{pod}}'
+                seriesNameFormat: '{{quantile}} - {{instance}}'
   variables:
   - kind: ListVariable
     spec:

--- a/examples/dashboards/operator/kubernetes/kubelet-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubelet-overview.yaml
@@ -1091,7 +1091,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                seriesNameFormat: Alloc All {{pod}}
+                seriesNameFormat: Alloc All {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -1101,7 +1101,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                seriesNameFormat: Alloc Heap {{pod}}
+                seriesNameFormat: Alloc Heap {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -1114,7 +1114,7 @@ spec:
                   rate(
                     go_memstats_alloc_bytes_total{cluster=~"$cluster",instance=~"$instance",job="kubelet"}[$__rate_interval]
                   )
-                seriesNameFormat: Alloc Rate All {{pod}}
+                seriesNameFormat: Alloc Rate All {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -1127,7 +1127,7 @@ spec:
                   rate(
                     go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}[$__rate_interval]
                   )
-                seriesNameFormat: Alloc Rate Heap {{pod}}
+                seriesNameFormat: Alloc Rate Heap {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -1137,7 +1137,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                seriesNameFormat: Inuse Stack {{pod}}
+                seriesNameFormat: Inuse Stack {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -1147,7 +1147,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                seriesNameFormat: Inuse Heap {{pod}}
+                seriesNameFormat: Inuse Heap {{instance}}
         - kind: TimeSeriesQuery
           spec:
             plugin:
@@ -1157,12 +1157,12 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                seriesNameFormat: Resident Memory {{pod}}
+                seriesNameFormat: Resident Memory {{instance}}
     "11_1":
       kind: Panel
       spec:
         display:
-          description: Kubelete CPU Usage
+          description: Shows the CPU usage of the component.
           name: CPU Usage
         plugin:
           kind: TimeSeriesChart
@@ -1225,7 +1225,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_goroutines{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                seriesNameFormat: '{{pod}}'
+                seriesNameFormat: '{{instance}}'
     "11_3":
       kind: Panel
       spec:
@@ -1259,7 +1259,7 @@ spec:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
                 query: go_gc_duration_seconds{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                seriesNameFormat: '{{quantile}} - {{pod}}'
+                seriesNameFormat: '{{quantile}} - {{instance}}'
   variables:
   - kind: ListVariable
     spec:

--- a/examples/dashboards/operator/perses/perses-overview.yaml
+++ b/examples/dashboards/operator/perses/perses-overview.yaml
@@ -346,7 +346,7 @@ spec:
       kind: Panel
       spec:
         display:
-          description: Shows CPU usage metrics
+          description: Shows the CPU usage of the component.
           name: CPU Usage
         plugin:
           kind: TimeSeriesChart
@@ -364,7 +364,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: percent
+                unit: decimal
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos/thanos-compact-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-compact-overview.yaml
@@ -194,20 +194,26 @@ spec:
       - content:
           $ref: '#/spec/panels/8_0'
         height: 8
-        width: 8
+        width: 6
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/8_1'
         height: 8
-        width: 8
-        x: 8
+        width: 6
+        x: 6
         "y": 0
       - content:
           $ref: '#/spec/panels/8_2'
         height: 8
-        width: 8
-        x: 16
+        width: 6
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/8_3'
+        height: 8
+        width: 6
+        x: 18
         "y": 0
   panels:
     "0_0":
@@ -1203,6 +1209,40 @@ spec:
       kind: Panel
       spec:
         display:
+          description: Shows the CPU usage of the component.
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                seriesNameFormat: '{{pod}}'
+    "8_1":
+      kind: Panel
+      spec:
+        display:
           description: Shows various memory usage metrics of the component.
           name: Memory Usage
         plugin:
@@ -1293,7 +1333,7 @@ spec:
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: Resident Memory {{pod}}
-    "8_1":
+    "8_2":
       kind: Panel
       spec:
         display:
@@ -1327,7 +1367,7 @@ spec:
                   name: prometheus-datasource
                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: '{{pod}}'
-    "8_2":
+    "8_3":
       kind: Panel
       spec:
         display:

--- a/examples/dashboards/operator/thanos/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-query-frontend-overview.yaml
@@ -80,20 +80,26 @@ spec:
       - content:
           $ref: '#/spec/panels/2_0'
         height: 8
-        width: 8
+        width: 6
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/2_1'
         height: 8
-        width: 8
-        x: 8
+        width: 6
+        x: 6
         "y": 0
       - content:
           $ref: '#/spec/panels/2_2'
         height: 8
-        width: 8
-        x: 16
+        width: 6
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_3'
+        height: 8
+        width: 6
+        x: 18
         "y": 0
   panels:
     "0_0":
@@ -438,6 +444,40 @@ spec:
       kind: Panel
       spec:
         display:
+          description: Shows the CPU usage of the component.
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                seriesNameFormat: '{{pod}}'
+    "2_1":
+      kind: Panel
+      spec:
+        display:
           description: Shows various memory usage metrics of the component.
           name: Memory Usage
         plugin:
@@ -528,7 +568,7 @@ spec:
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: Resident Memory {{pod}}
-    "2_1":
+    "2_2":
       kind: Panel
       spec:
         display:
@@ -562,7 +602,7 @@ spec:
                   name: prometheus-datasource
                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: '{{pod}}'
-    "2_2":
+    "2_3":
       kind: Panel
       spec:
         display:

--- a/examples/dashboards/operator/thanos/thanos-query-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-query-overview.yaml
@@ -142,20 +142,26 @@ spec:
       - content:
           $ref: '#/spec/panels/6_0'
         height: 8
-        width: 8
+        width: 6
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/6_1'
         height: 8
-        width: 8
-        x: 8
+        width: 6
+        x: 6
         "y": 0
       - content:
           $ref: '#/spec/panels/6_2'
         height: 8
-        width: 8
-        x: 16
+        width: 6
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/6_3'
+        height: 8
+        width: 6
+        x: 18
         "y": 0
   panels:
     "0_0":
@@ -913,6 +919,40 @@ spec:
       kind: Panel
       spec:
         display:
+          description: Shows the CPU usage of the component.
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                seriesNameFormat: '{{pod}}'
+    "6_1":
+      kind: Panel
+      spec:
+        display:
           description: Shows various memory usage metrics of the component.
           name: Memory Usage
         plugin:
@@ -1003,7 +1043,7 @@ spec:
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: Resident Memory {{pod}}
-    "6_1":
+    "6_2":
       kind: Panel
       spec:
         display:
@@ -1037,7 +1077,7 @@ spec:
                   name: prometheus-datasource
                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: '{{pod}}'
-    "6_2":
+    "6_3":
       kind: Panel
       spec:
         display:

--- a/examples/dashboards/operator/thanos/thanos-receive-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-receive-overview.yaml
@@ -257,20 +257,26 @@ spec:
       - content:
           $ref: '#/spec/panels/11_0'
         height: 8
-        width: 8
+        width: 6
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/11_1'
         height: 8
-        width: 8
-        x: 8
+        width: 6
+        x: 6
         "y": 0
       - content:
           $ref: '#/spec/panels/11_2'
         height: 8
-        width: 8
-        x: 16
+        width: 6
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/11_3'
+        height: 8
+        width: 6
+        x: 18
         "y": 0
   panels:
     "0_0":
@@ -1567,6 +1573,40 @@ spec:
       kind: Panel
       spec:
         display:
+          description: Shows the CPU usage of the component.
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                seriesNameFormat: '{{pod}}'
+    "11_1":
+      kind: Panel
+      spec:
+        display:
           description: Shows various memory usage metrics of the component.
           name: Memory Usage
         plugin:
@@ -1657,7 +1697,7 @@ spec:
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: Resident Memory {{pod}}
-    "11_1":
+    "11_2":
       kind: Panel
       spec:
         display:
@@ -1691,7 +1731,7 @@ spec:
                   name: prometheus-datasource
                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: '{{pod}}'
-    "11_2":
+    "11_3":
       kind: Panel
       spec:
         display:

--- a/examples/dashboards/operator/thanos/thanos-ruler-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-ruler-overview.yaml
@@ -149,20 +149,26 @@ spec:
       - content:
           $ref: '#/spec/panels/5_0'
         height: 8
-        width: 8
+        width: 6
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/5_1'
         height: 8
-        width: 8
-        x: 8
+        width: 6
+        x: 6
         "y": 0
       - content:
           $ref: '#/spec/panels/5_2'
         height: 8
-        width: 8
-        x: 16
+        width: 6
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/5_3'
+        height: 8
+        width: 6
+        x: 18
         "y": 0
   panels:
     "0_0":
@@ -934,6 +940,40 @@ spec:
       kind: Panel
       spec:
         display:
+          description: Shows the CPU usage of the component.
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                seriesNameFormat: '{{pod}}'
+    "5_1":
+      kind: Panel
+      spec:
+        display:
           description: Shows various memory usage metrics of the component.
           name: Memory Usage
         plugin:
@@ -1024,7 +1064,7 @@ spec:
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: Resident Memory {{pod}}
-    "5_1":
+    "5_2":
       kind: Panel
       spec:
         display:
@@ -1058,7 +1098,7 @@ spec:
                   name: prometheus-datasource
                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: '{{pod}}'
-    "5_2":
+    "5_3":
       kind: Panel
       spec:
         display:

--- a/examples/dashboards/operator/thanos/thanos-store-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-store-overview.yaml
@@ -212,20 +212,26 @@ spec:
       - content:
           $ref: '#/spec/panels/8_0'
         height: 8
-        width: 8
+        width: 6
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/8_1'
         height: 8
-        width: 8
-        x: 8
+        width: 6
+        x: 6
         "y": 0
       - content:
           $ref: '#/spec/panels/8_2'
         height: 8
-        width: 8
-        x: 16
+        width: 6
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/8_3'
+        height: 8
+        width: 6
+        x: 18
         "y": 0
   panels:
     "0_0":
@@ -1719,6 +1725,40 @@ spec:
       kind: Panel
       spec:
         display:
+          description: Shows the CPU usage of the component.
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                seriesNameFormat: '{{pod}}'
+    "8_1":
+      kind: Panel
+      spec:
+        display:
           description: Shows various memory usage metrics of the component.
           name: Memory Usage
         plugin:
@@ -1809,7 +1849,7 @@ spec:
                   name: prometheus-datasource
                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: Resident Memory {{pod}}
-    "8_1":
+    "8_2":
       kind: Panel
       spec:
         display:
@@ -1843,7 +1883,7 @@ spec:
                   name: prometheus-datasource
                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                 seriesNameFormat: '{{pod}}'
-    "8_2":
+    "8_3":
       kind: Panel
       spec:
         display:

--- a/examples/dashboards/perses/kubernetes/controller-manager-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/controller-manager-overview.yaml
@@ -383,7 +383,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                                seriesNameFormat: Alloc All {{pod}}
+                                seriesNameFormat: Alloc All {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -393,7 +393,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                                seriesNameFormat: Alloc Heap {{pod}}
+                                seriesNameFormat: Alloc Heap {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -406,7 +406,7 @@ spec:
                                     rate(
                                       go_memstats_alloc_bytes_total{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
                                     )
-                                seriesNameFormat: Alloc Rate All {{pod}}
+                                seriesNameFormat: Alloc Rate All {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -419,7 +419,7 @@ spec:
                                     rate(
                                       go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
                                     )
-                                seriesNameFormat: Alloc Rate Heap {{pod}}
+                                seriesNameFormat: Alloc Rate Heap {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -429,7 +429,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                                seriesNameFormat: Inuse Stack {{pod}}
+                                seriesNameFormat: Inuse Stack {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -439,7 +439,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                                seriesNameFormat: Inuse Heap {{pod}}
+                                seriesNameFormat: Inuse Heap {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -449,13 +449,13 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                                seriesNameFormat: Resident Memory {{pod}}
+                                seriesNameFormat: Resident Memory {{instance}}
         "3_1":
             kind: Panel
             spec:
                 display:
                     name: CPU Usage
-                    description: Kubelete CPU Usage
+                    description: Shows the CPU usage of the component.
                 plugin:
                     kind: TimeSeriesChart
                     spec:
@@ -520,7 +520,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_goroutines{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                                seriesNameFormat: '{{pod}}'
+                                seriesNameFormat: '{{instance}}'
         "3_3":
             kind: Panel
             spec:
@@ -554,7 +554,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_gc_duration_seconds{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
-                                seriesNameFormat: '{{quantile}} - {{pod}}'
+                                seriesNameFormat: '{{quantile}} - {{instance}}'
     layouts:
         - kind: Grid
           spec:

--- a/examples/dashboards/perses/kubernetes/kubelet-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubelet-overview.yaml
@@ -907,7 +907,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                                seriesNameFormat: Alloc All {{pod}}
+                                seriesNameFormat: Alloc All {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -917,7 +917,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                                seriesNameFormat: Alloc Heap {{pod}}
+                                seriesNameFormat: Alloc Heap {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -930,7 +930,7 @@ spec:
                                     rate(
                                       go_memstats_alloc_bytes_total{cluster=~"$cluster",instance=~"$instance",job="kubelet"}[$__rate_interval]
                                     )
-                                seriesNameFormat: Alloc Rate All {{pod}}
+                                seriesNameFormat: Alloc Rate All {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -943,7 +943,7 @@ spec:
                                     rate(
                                       go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}[$__rate_interval]
                                     )
-                                seriesNameFormat: Alloc Rate Heap {{pod}}
+                                seriesNameFormat: Alloc Rate Heap {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -953,7 +953,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                                seriesNameFormat: Inuse Stack {{pod}}
+                                seriesNameFormat: Inuse Stack {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -963,7 +963,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                                seriesNameFormat: Inuse Heap {{pod}}
+                                seriesNameFormat: Inuse Heap {{instance}}
                     - kind: TimeSeriesQuery
                       spec:
                         plugin:
@@ -973,13 +973,13 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                                seriesNameFormat: Resident Memory {{pod}}
+                                seriesNameFormat: Resident Memory {{instance}}
         "11_1":
             kind: Panel
             spec:
                 display:
                     name: CPU Usage
-                    description: Kubelete CPU Usage
+                    description: Shows the CPU usage of the component.
                 plugin:
                     kind: TimeSeriesChart
                     spec:
@@ -1041,7 +1041,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_goroutines{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                                seriesNameFormat: '{{pod}}'
+                                seriesNameFormat: '{{instance}}'
         "11_3":
             kind: Panel
             spec:
@@ -1075,7 +1075,7 @@ spec:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
                                 query: go_gc_duration_seconds{cluster=~"$cluster",instance=~"$instance",job="kubelet"}
-                                seriesNameFormat: '{{quantile}} - {{pod}}'
+                                seriesNameFormat: '{{quantile}} - {{instance}}'
     layouts:
         - kind: Grid
           spec:

--- a/examples/dashboards/perses/perses/perses-overview.yaml
+++ b/examples/dashboards/perses/perses/perses-overview.yaml
@@ -296,7 +296,7 @@ spec:
             spec:
                 display:
                     name: CPU Usage
-                    description: Shows CPU usage metrics
+                    description: Shows the CPU usage of the component.
                 plugin:
                     kind: TimeSeriesChart
                     spec:
@@ -307,7 +307,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: percent
+                                unit: decimal
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/thanos/thanos-compact-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-compact-overview.yaml
@@ -1023,6 +1023,40 @@ spec:
             kind: Panel
             spec:
                 display:
+                    name: CPU Usage
+                    description: Shows the CPU usage of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                                seriesNameFormat: '{{pod}}'
+        "8_1":
+            kind: Panel
+            spec:
+                display:
                     name: Memory Usage
                     description: Shows various memory usage metrics of the component.
                 plugin:
@@ -1113,7 +1147,7 @@ spec:
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: Resident Memory {{pod}}
-        "8_1":
+        "8_2":
             kind: Panel
             spec:
                 display:
@@ -1147,7 +1181,7 @@ spec:
                                     name: prometheus-datasource
                                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: '{{pod}}'
-        "8_2":
+        "8_3":
             kind: Panel
             spec:
                 display:
@@ -1361,20 +1395,26 @@ spec:
             items:
                 - x: 0
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/8_0'
-                - x: 8
+                - x: 6
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/8_1'
-                - x: 16
+                - x: 12
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/8_2'
+                - x: 18
+                  "y": 0
+                  width: 6
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/8_3'
     duration: 1h

--- a/examples/dashboards/perses/thanos/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-query-frontend-overview.yaml
@@ -384,6 +384,40 @@ spec:
             kind: Panel
             spec:
                 display:
+                    name: CPU Usage
+                    description: Shows the CPU usage of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                                seriesNameFormat: '{{pod}}'
+        "2_1":
+            kind: Panel
+            spec:
+                display:
                     name: Memory Usage
                     description: Shows various memory usage metrics of the component.
                 plugin:
@@ -474,7 +508,7 @@ spec:
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: Resident Memory {{pod}}
-        "2_1":
+        "2_2":
             kind: Panel
             spec:
                 display:
@@ -508,7 +542,7 @@ spec:
                                     name: prometheus-datasource
                                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: '{{pod}}'
-        "2_2":
+        "2_3":
             kind: Panel
             spec:
                 display:
@@ -608,20 +642,26 @@ spec:
             items:
                 - x: 0
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/2_0'
-                - x: 8
+                - x: 6
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/2_1'
-                - x: 16
+                - x: 12
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/2_2'
+                - x: 18
+                  "y": 0
+                  width: 6
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/2_3'
     duration: 1h

--- a/examples/dashboards/perses/thanos/thanos-query-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-query-overview.yaml
@@ -790,6 +790,40 @@ spec:
             kind: Panel
             spec:
                 display:
+                    name: CPU Usage
+                    description: Shows the CPU usage of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                                seriesNameFormat: '{{pod}}'
+        "6_1":
+            kind: Panel
+            spec:
+                display:
                     name: Memory Usage
                     description: Shows various memory usage metrics of the component.
                 plugin:
@@ -880,7 +914,7 @@ spec:
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: Resident Memory {{pod}}
-        "6_1":
+        "6_2":
             kind: Panel
             spec:
                 display:
@@ -914,7 +948,7 @@ spec:
                                     name: prometheus-datasource
                                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: '{{pod}}'
-        "6_2":
+        "6_3":
             kind: Panel
             spec:
                 display:
@@ -1076,20 +1110,26 @@ spec:
             items:
                 - x: 0
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/6_0'
-                - x: 8
+                - x: 6
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/6_1'
-                - x: 16
+                - x: 12
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/6_2'
+                - x: 18
+                  "y": 0
+                  width: 6
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/6_3'
     duration: 1h

--- a/examples/dashboards/perses/thanos/thanos-receive-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-receive-overview.yaml
@@ -1348,6 +1348,40 @@ spec:
             kind: Panel
             spec:
                 display:
+                    name: CPU Usage
+                    description: Shows the CPU usage of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                                seriesNameFormat: '{{pod}}'
+        "11_1":
+            kind: Panel
+            spec:
+                display:
                     name: Memory Usage
                     description: Shows various memory usage metrics of the component.
                 plugin:
@@ -1438,7 +1472,7 @@ spec:
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: Resident Memory {{pod}}
-        "11_1":
+        "11_2":
             kind: Panel
             spec:
                 display:
@@ -1472,7 +1506,7 @@ spec:
                                     name: prometheus-datasource
                                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: '{{pod}}'
-        "11_2":
+        "11_3":
             kind: Panel
             spec:
                 display:
@@ -1749,20 +1783,26 @@ spec:
             items:
                 - x: 0
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/11_0'
-                - x: 8
+                - x: 6
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/11_1'
-                - x: 16
+                - x: 12
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/11_2'
+                - x: 18
+                  "y": 0
+                  width: 6
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/11_3'
     duration: 1h

--- a/examples/dashboards/perses/thanos/thanos-ruler-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-ruler-overview.yaml
@@ -804,6 +804,40 @@ spec:
             kind: Panel
             spec:
                 display:
+                    name: CPU Usage
+                    description: Shows the CPU usage of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                                seriesNameFormat: '{{pod}}'
+        "5_1":
+            kind: Panel
+            spec:
+                display:
                     name: Memory Usage
                     description: Shows various memory usage metrics of the component.
                 plugin:
@@ -894,7 +928,7 @@ spec:
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: Resident Memory {{pod}}
-        "5_1":
+        "5_2":
             kind: Panel
             spec:
                 display:
@@ -928,7 +962,7 @@ spec:
                                     name: prometheus-datasource
                                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: '{{pod}}'
-        "5_2":
+        "5_3":
             kind: Panel
             spec:
                 display:
@@ -1097,20 +1131,26 @@ spec:
             items:
                 - x: 0
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/5_0'
-                - x: 8
+                - x: 6
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/5_1'
-                - x: 16
+                - x: 12
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/5_2'
+                - x: 18
+                  "y": 0
+                  width: 6
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/5_3'
     duration: 1h

--- a/examples/dashboards/perses/thanos/thanos-store-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-store-overview.yaml
@@ -1519,6 +1519,40 @@ spec:
             kind: Panel
             spec:
                 display:
+                    name: CPU Usage
+                    description: Shows the CPU usage of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(process_cpu_seconds_total{job=~"$job",namespace="$namespace"}[$__rate_interval])
+                                seriesNameFormat: '{{pod}}'
+        "8_1":
+            kind: Panel
+            spec:
+                display:
                     name: Memory Usage
                     description: Shows various memory usage metrics of the component.
                 plugin:
@@ -1609,7 +1643,7 @@ spec:
                                     name: prometheus-datasource
                                 query: process_resident_memory_bytes{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: Resident Memory {{pod}}
-        "8_1":
+        "8_2":
             kind: Panel
             spec:
                 display:
@@ -1643,7 +1677,7 @@ spec:
                                     name: prometheus-datasource
                                 query: go_goroutines{job=~"$job",namespace="$namespace"}
                                 seriesNameFormat: '{{pod}}'
-        "8_2":
+        "8_3":
             kind: Panel
             spec:
                 display:
@@ -1875,20 +1909,26 @@ spec:
             items:
                 - x: 0
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/8_0'
-                - x: 8
+                - x: 6
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/8_1'
-                - x: 16
+                - x: 12
                   "y": 0
-                  width: 8
+                  width: 6
                   height: 8
                   content:
                     $ref: '#/spec/panels/8_2'
+                - x: 18
+                  "y": 0
+                  width: 6
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/8_3'
     duration: 1h

--- a/pkg/dashboards/kubernetes/controller_manager/controller_manager.go
+++ b/pkg/dashboards/kubernetes/controller_manager/controller_manager.go
@@ -56,10 +56,10 @@ func withCMResources(datasource string, clusterLabelMatcher promql.LabelMatcher)
 	return dashboard.AddPanelGroup("Resource Usage",
 		panelgroup.PanelsPerLine(2),
 		panelgroup.PanelHeight(8),
-		panelsGostats.MemoryUsage(datasource, labelMatchersToUse...),
-		panels.KubeletCPU(datasource, labelMatchersToUse...),
-		panelsGostats.Goroutines(datasource, labelMatchersToUse...),
-		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, labelMatchersToUse...),
+		panelsGostats.MemoryUsage(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.CPUUsage(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.Goroutines(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, "instance", labelMatchersToUse...),
 	)
 }
 

--- a/pkg/dashboards/kubernetes/kubelet/kubelet.go
+++ b/pkg/dashboards/kubernetes/kubelet/kubelet.go
@@ -115,10 +115,10 @@ func withKubeletResources(datasource string, clusterLabelMatcher promql.LabelMat
 	return dashboard.AddPanelGroup("Resource Usage",
 		panelgroup.PanelsPerLine(2),
 		panelgroup.PanelHeight(10),
-		panelsGostats.MemoryUsage(datasource, labelMatchersToUse...),
-		panels.KubeletCPU(datasource, labelMatchersToUse...),
-		panelsGostats.Goroutines(datasource, labelMatchersToUse...),
-		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, labelMatchersToUse...),
+		panelsGostats.MemoryUsage(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.CPUUsage(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.Goroutines(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, "instance", labelMatchersToUse...),
 	)
 }
 

--- a/pkg/dashboards/perses/perses_overview.go
+++ b/pkg/dashboards/perses/perses_overview.go
@@ -71,10 +71,10 @@ func withPersesResources(datasource string, clusterLabelMatcher promql.LabelMatc
 	return dashboard.AddPanelGroup("Resource Usage",
 		panelgroup.PanelsPerLine(3),
 		panelgroup.PanelHeight(10),
-		panelsGostats.MemoryUsage(datasource, labelMatchersToUse...),
-		perses.CPUUsage(datasource, clusterLabelMatcher),
-		panelsGostats.Goroutines(datasource, labelMatchersToUse...),
-		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, labelMatchersToUse...),
+		panelsGostats.MemoryUsage(datasource, "pod", labelMatchersToUse...),
+		panelsGostats.CPUUsage(datasource, "pod", labelMatchersToUse...),
+		panelsGostats.Goroutines(datasource, "pod", labelMatchersToUse...),
+		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, "pod", labelMatchersToUse...),
 		perses.FileDescriptors(datasource, clusterLabelMatcher),
 	)
 }

--- a/pkg/dashboards/thanos/common.go
+++ b/pkg/dashboards/thanos/common.go
@@ -17,11 +17,12 @@ func withThanosResourcesGroup(datasource string, labelMatcher promql.LabelMatche
 	labelMatchersToUse = append(labelMatchersToUse, labelMatcher)
 
 	return dashboard.AddPanelGroup("Resources",
-		panelgroup.PanelsPerLine(3),
+		panelgroup.PanelsPerLine(4),
 		panelgroup.PanelHeight(8),
-		panelsGostats.MemoryUsage(datasource, labelMatchersToUse...),
-		panelsGostats.Goroutines(datasource, labelMatchersToUse...),
-		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, labelMatchersToUse...),
+		panelsGostats.CPUUsage(datasource, "pod", labelMatchersToUse...),
+		panelsGostats.MemoryUsage(datasource, "pod", labelMatchersToUse...),
+		panelsGostats.Goroutines(datasource, "pod", labelMatchersToUse...),
+		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, "pod", labelMatchersToUse...),
 	)
 }
 

--- a/pkg/panels/gostats/gostats.go
+++ b/pkg/panels/gostats/gostats.go
@@ -12,7 +12,7 @@ import (
 	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
 )
 
-func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+func MemoryUsage(datasourceName string, seriesNameToUse string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Memory Usage",
 		panel.Description("Shows various memory usage metrics of the component."),
 		timeSeriesPanel.Chart(
@@ -41,7 +41,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("Alloc All {{pod}}"),
+				query.SeriesNameFormat("Alloc All {{"+seriesNameToUse+"}}"),
 			),
 		),
 		panel.AddQuery(
@@ -51,7 +51,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("Alloc Heap {{pod}}"),
+				query.SeriesNameFormat("Alloc Heap {{"+seriesNameToUse+"}}"),
 			),
 		),
 		panel.AddQuery(
@@ -61,7 +61,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("Alloc Rate All {{pod}}"),
+				query.SeriesNameFormat("Alloc Rate All {{"+seriesNameToUse+"}}"),
 			),
 		),
 		panel.AddQuery(
@@ -71,7 +71,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("Alloc Rate Heap {{pod}}"),
+				query.SeriesNameFormat("Alloc Rate Heap {{"+seriesNameToUse+"}}"),
 			),
 		),
 		panel.AddQuery(
@@ -81,7 +81,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("Inuse Stack {{pod}}"),
+				query.SeriesNameFormat("Inuse Stack {{"+seriesNameToUse+"}}"),
 			),
 		),
 		panel.AddQuery(
@@ -91,7 +91,7 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("Inuse Heap {{pod}}"),
+				query.SeriesNameFormat("Inuse Heap {{"+seriesNameToUse+"}}"),
 			),
 		),
 		panel.AddQuery(
@@ -101,13 +101,13 @@ func MemoryUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("Resident Memory {{pod}}"),
+				query.SeriesNameFormat("Resident Memory {{"+seriesNameToUse+"}}"),
 			),
 		),
 	)
 }
 
-func Goroutines(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+func Goroutines(datasourceName string, seriesNameToUse string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("Goroutines",
 		panel.Description("Shows the number of goroutines being used by the component."),
 		timeSeriesPanel.Chart(
@@ -136,13 +136,13 @@ func Goroutines(datasourceName string, labelMatchers ...promql.LabelMatcher) pan
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{pod}}"),
+				query.SeriesNameFormat("{{"+seriesNameToUse+"}}"),
 			),
 		),
 	)
 }
 
-func GarbageCollectionPauseTimeQuantiles(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+func GarbageCollectionPauseTimeQuantiles(datasourceName string, seriesNameToUse string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("GC Duration",
 		panel.Description("Shows the Go garbage collection pause durations for the component."),
 		timeSeriesPanel.Chart(
@@ -171,7 +171,42 @@ func GarbageCollectionPauseTimeQuantiles(datasourceName string, labelMatchers ..
 					labelMatchers,
 				),
 				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{quantile}} - {{pod}}"),
+				query.SeriesNameFormat("{{quantile}} - {{"+seriesNameToUse+"}}"),
+			),
+		),
+	)
+}
+
+func CPUUsage(datasourceName string, seriesNameToUse string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("CPU Usage",
+		panel.Description("Shows the CPU usage of the component."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.DecimalUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"rate(process_cpu_seconds_total[$__rate_interval])",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{"+seriesNameToUse+"}}"),
 			),
 		),
 	)

--- a/pkg/panels/kubernetes/kubelet.go
+++ b/pkg/panels/kubernetes/kubelet.go
@@ -723,39 +723,3 @@ func RequestDurationQuantile(datasourceName string, labelMatchers ...promql.Labe
 		),
 	)
 }
-
-func KubeletCPU(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
-	return panelgroup.AddPanel("CPU Usage",
-		panel.Description("Kubelete CPU Usage"),
-		timeSeriesPanel.Chart(
-			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
-				Format: &commonSdk.Format{
-					Unit:          string(commonSdk.DecimalUnit),
-					DecimalPlaces: 0,
-				},
-			}),
-			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
-				Position: timeSeriesPanel.BottomPosition,
-				Mode:     timeSeriesPanel.TableMode,
-				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
-			}),
-			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
-				Display:      timeSeriesPanel.LineDisplay,
-				ConnectNulls: false,
-				LineWidth:    0.25,
-				AreaOpacity:  0.5,
-				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
-			}),
-		),
-		panel.AddQuery(
-			query.PromQL(
-				promql.SetLabelMatchers(
-					"rate(process_cpu_seconds_total{cluster=~'$cluster',"+GetKubeletMatcher()+", instance=~'$instance'}[$__rate_interval])",
-					labelMatchers,
-				),
-				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{instance}}"),
-			),
-		),
-	)
-}

--- a/pkg/panels/perses/perses.go
+++ b/pkg/panels/perses/perses.go
@@ -166,42 +166,6 @@ func HTTPErrorPercentagePanel(datasourceName string, labelMatchers ...promql.Lab
 	)
 }
 
-func CPUUsage(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
-	return panelgroup.AddPanel("CPU Usage",
-		panel.Description("Shows CPU usage metrics"),
-		timeSeriesPanel.Chart(
-			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
-				Format: &common.Format{
-					Unit: string(common.PercentUnit),
-				},
-			},
-			),
-			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
-				Position: timeSeriesPanel.BottomPosition,
-				Mode:     timeSeriesPanel.TableMode,
-				Values:   []common.Calculation{common.LastCalculation},
-			}),
-			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
-				Display:      timeSeriesPanel.LineDisplay,
-				ConnectNulls: false,
-				LineWidth:    0.25,
-				AreaOpacity:  0.5,
-				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
-			}),
-		),
-		panel.AddQuery(
-			query.PromQL(
-				promql.SetLabelMatchers(
-					"rate(process_cpu_seconds_total{job=~'$job', instance=~'$instance'}[$__rate_interval])",
-					labelMatchers,
-				),
-				dashboards.AddQueryDataSource(datasourceName),
-				query.SeriesNameFormat("{{pod}}"),
-			),
-		),
-	)
-}
-
 func FileDescriptors(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
 	return panelgroup.AddPanel("File Descriptors",
 		panel.Description("Displays the number of open and max file descriptors."),


### PR DESCRIPTION
This commit brings the CPU usage panel into gostats, and uses the same in perses, kubelet, and thanos dashboards.

As the panel is based on client_golang process collector, it should fit a variety of use cases.

Also, adds a seriesNameToUse arg to gostats panels, as certain dashboards need to label by {{pod}} and others by {{instance}}.