### PR TITLE
Add dashboard for Kube Controller Manager

### DIFF
--- a/examples/dashboards/operator/kubernetes/controller-manager-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/controller-manager-overview.yaml
@@ -1,0 +1,653 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: controller-manager-overview
+    app.kubernetes.io/name: perses-dashboard
+    app.kubernetes.io/part-of: perses-operator
+  name: controller-manager-overview
+  namespace: perses-dev
+spec:
+  display:
+    name: Kubernetes / Controller Manager
+  duration: 1h
+  layouts:
+  - kind: Grid
+    spec:
+      display:
+        title: Controller Manager Status
+      items:
+      - content:
+          $ref: '#/spec/panels/0_0'
+        height: 8
+        width: 24
+        x: 0
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Work Queue
+      items:
+      - content:
+          $ref: '#/spec/panels/1_0'
+        height: 8
+        width: 8
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/1_1'
+        height: 8
+        width: 8
+        x: 8
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/1_2'
+        height: 8
+        width: 8
+        x: 16
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Kube API Requests
+      items:
+      - content:
+          $ref: '#/spec/panels/2_0'
+        height: 8
+        width: 8
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_1'
+        height: 8
+        width: 8
+        x: 8
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_2'
+        height: 8
+        width: 8
+        x: 16
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Resource Usage
+      items:
+      - content:
+          $ref: '#/spec/panels/3_0'
+        height: 8
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/3_1'
+        height: 8
+        width: 12
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/3_2'
+        height: 8
+        width: 12
+        x: 0
+        "y": 8
+      - content:
+          $ref: '#/spec/panels/3_3'
+        height: 8
+        width: 12
+        x: 12
+        "y": 8
+  panels:
+    "0_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the status of the controller manager.
+          name: Up
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+            valueFontSize: 50
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: sum(up{cluster="$cluster",job="kube-controller-manager"})
+    "1_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the rate of work queue add events.
+          name: Work Queue Add Rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: list
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (cluster, instance, name) (
+                    rate(
+                      workqueue_adds_total{cluster="$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                    )
+                  )
+                seriesNameFormat: '{{cluster}} {{instance}} {{name}}'
+    "1_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the depth of the work queue.
+          name: Work Queue Depth
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: list
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (cluster, instance, name) (
+                    rate(
+                      workqueue_depth{cluster="$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                    )
+                  )
+                seriesNameFormat: '{{cluster}} {{instance}} {{name}}'
+    "1_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the 99th percentile latency of items queued in the work
+            queue.
+          name: Work Queue Latency
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: list
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.99,
+                    sum by (cluster, instance, name, le) (
+                      rate(
+                        workqueue_queue_duration_seconds_bucket{cluster="$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                      )
+                    )
+                  )
+                seriesNameFormat: '{{cluster}} {{instance}} {{name}}'
+    "2_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the rate of requests to the Kube API.
+          name: Kube API Request Rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: list
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+              stack: all
+            yAxis:
+              format:
+                unit: requests/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum(
+                    rate(
+                      rest_client_requests_total{code=~"2..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                    )
+                  )
+                seriesNameFormat: 2xx
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum(
+                    rate(
+                      rest_client_requests_total{code=~"3..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                    )
+                  )
+                seriesNameFormat: 3xx
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum(
+                    rate(
+                      rest_client_requests_total{code=~"4..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                    )
+                  )
+                seriesNameFormat: 4xx
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum(
+                    rate(
+                      rest_client_requests_total{code=~"5..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                    )
+                  )
+                seriesNameFormat: 5xx
+    "2_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the 99th quantile latency of post requests to the Kube
+            API.
+          name: Post Request Latency 99th Quantile
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: list
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.99,
+                    sum by (verb, le) (
+                      rate(
+                        rest_client_request_duration_seconds_bucket{cluster="$cluster",instance=~"$instance",job="kube-controller-manager",verb="POST"}[$__rate_interval]
+                      )
+                    )
+                  )
+                seriesNameFormat: '{{verb}}'
+    "2_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the 99th quantile latency of get requests to the Kube
+            API.
+          name: Get Request Latency 99th Quantile
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: list
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.99,
+                    sum by (verb, le) (
+                      rate(
+                        rest_client_request_duration_seconds_bucket{cluster="$cluster",instance=~"$instance",job="kube-controller-manager",verb="GET"}[$__rate_interval]
+                      )
+                    )
+                  )
+                seriesNameFormat: '{{verb}}'
+    "3_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows various memory usage metrics of the component.
+          name: Memory Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: bytes
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                seriesNameFormat: Alloc All {{pod}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                seriesNameFormat: Alloc Heap {{pod}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  rate(
+                    go_memstats_alloc_bytes_total{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                  )
+                seriesNameFormat: Alloc Rate All {{pod}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  rate(
+                    go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                  )
+                seriesNameFormat: Alloc Rate Heap {{pod}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                seriesNameFormat: Inuse Stack {{pod}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                seriesNameFormat: Inuse Heap {{pod}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: process_resident_memory_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                seriesNameFormat: Resident Memory {{pod}}
+    "3_1":
+      kind: Panel
+      spec:
+        display:
+          description: Kubelete CPU Usage
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  rate(
+                    process_cpu_seconds_total{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                  )
+                seriesNameFormat: '{{instance}}'
+    "3_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the number of goroutines being used by the component.
+          name: Goroutines
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_goroutines{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                seriesNameFormat: '{{pod}}'
+    "3_3":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the Go garbage collection pause durations for the component.
+          name: GC Duration
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: milliseconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_gc_duration_seconds{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                seriesNameFormat: '{{quantile}} - {{pod}}'
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: cluster
+      name: cluster
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: cluster
+          matchers:
+          - up{job="kube-controller-manager"}
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: instance
+      name: instance
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: instance
+          matchers:
+          - up{cluster="$cluster",job="kube-controller-manager"}
+status: {}

--- a/examples/dashboards/perses/kubernetes/controller-manager-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/controller-manager-overview.yaml
@@ -1,0 +1,645 @@
+kind: Dashboard
+metadata:
+    name: controller-manager-overview
+    createdAt: 0001-01-01T00:00:00Z
+    updatedAt: 0001-01-01T00:00:00Z
+    version: 0
+    project: perses-dev
+spec:
+    display:
+        name: Kubernetes / Controller Manager
+    variables:
+        - kind: ListVariable
+          spec:
+            display:
+                name: cluster
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: cluster
+                    matchers:
+                        - up{job="kube-controller-manager"}
+            name: cluster
+        - kind: ListVariable
+          spec:
+            display:
+                name: instance
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: instance
+                    matchers:
+                        - up{cluster="$cluster",job="kube-controller-manager"}
+            name: instance
+    panels:
+        "0_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Up
+                    description: Shows the status of the controller manager.
+                plugin:
+                    kind: StatChart
+                    spec:
+                        calculation: last
+                        format:
+                            unit: decimal
+                        valueFontSize: 50
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: sum(up{cluster="$cluster",job="kube-controller-manager"})
+        "1_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Work Queue Add Rate
+                    description: Shows the rate of work queue add events.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: list
+                            size: small
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (cluster, instance, name) (
+                                      rate(
+                                        workqueue_adds_total{cluster="$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                      )
+                                    )
+                                seriesNameFormat: '{{cluster}} {{instance}} {{name}}'
+        "1_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Work Queue Depth
+                    description: Shows the depth of the work queue.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: list
+                            size: small
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (cluster, instance, name) (
+                                      rate(
+                                        workqueue_depth{cluster="$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                      )
+                                    )
+                                seriesNameFormat: '{{cluster}} {{instance}} {{name}}'
+        "1_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Work Queue Latency
+                    description: Shows the 99th percentile latency of items queued in the work queue.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: list
+                            size: small
+                        yAxis:
+                            format:
+                                unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.99,
+                                      sum by (cluster, instance, name, le) (
+                                        rate(
+                                          workqueue_queue_duration_seconds_bucket{cluster="$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                        )
+                                      )
+                                    )
+                                seriesNameFormat: '{{cluster}} {{instance}} {{name}}'
+        "2_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Kube API Request Rate
+                    description: Shows the rate of requests to the Kube API.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: list
+                            size: small
+                        yAxis:
+                            format:
+                                unit: requests/sec
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
+                            stack: all
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum(
+                                      rate(
+                                        rest_client_requests_total{code=~"2..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                      )
+                                    )
+                                seriesNameFormat: 2xx
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum(
+                                      rate(
+                                        rest_client_requests_total{code=~"3..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                      )
+                                    )
+                                seriesNameFormat: 3xx
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum(
+                                      rate(
+                                        rest_client_requests_total{code=~"4..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                      )
+                                    )
+                                seriesNameFormat: 4xx
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum(
+                                      rate(
+                                        rest_client_requests_total{code=~"5..",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                      )
+                                    )
+                                seriesNameFormat: 5xx
+        "2_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Post Request Latency 99th Quantile
+                    description: Shows the 99th quantile latency of post requests to the Kube API.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: list
+                            size: small
+                        yAxis:
+                            format:
+                                unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.99,
+                                      sum by (verb, le) (
+                                        rate(
+                                          rest_client_request_duration_seconds_bucket{cluster="$cluster",instance=~"$instance",job="kube-controller-manager",verb="POST"}[$__rate_interval]
+                                        )
+                                      )
+                                    )
+                                seriesNameFormat: '{{verb}}'
+        "2_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Get Request Latency 99th Quantile
+                    description: Shows the 99th quantile latency of get requests to the Kube API.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: list
+                            size: small
+                        yAxis:
+                            format:
+                                unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.99,
+                                      sum by (verb, le) (
+                                        rate(
+                                          rest_client_request_duration_seconds_bucket{cluster="$cluster",instance=~"$instance",job="kube-controller-manager",verb="GET"}[$__rate_interval]
+                                        )
+                                      )
+                                    )
+                                seriesNameFormat: '{{verb}}'
+        "3_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Memory Usage
+                    description: Shows various memory usage metrics of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                                seriesNameFormat: Alloc All {{pod}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                                seriesNameFormat: Alloc Heap {{pod}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    rate(
+                                      go_memstats_alloc_bytes_total{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                    )
+                                seriesNameFormat: Alloc Rate All {{pod}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    rate(
+                                      go_memstats_heap_alloc_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                    )
+                                seriesNameFormat: Alloc Rate Heap {{pod}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                                seriesNameFormat: Inuse Stack {{pod}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                                seriesNameFormat: Inuse Heap {{pod}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: process_resident_memory_bytes{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                                seriesNameFormat: Resident Memory {{pod}}
+        "3_1":
+            kind: Panel
+            spec:
+                display:
+                    name: CPU Usage
+                    description: Kubelete CPU Usage
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    rate(
+                                      process_cpu_seconds_total{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}[$__rate_interval]
+                                    )
+                                seriesNameFormat: '{{instance}}'
+        "3_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Goroutines
+                    description: Shows the number of goroutines being used by the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_goroutines{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                                seriesNameFormat: '{{pod}}'
+        "3_3":
+            kind: Panel
+            spec:
+                display:
+                    name: GC Duration
+                    description: Shows the Go garbage collection pause durations for the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: milliseconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_gc_duration_seconds{cluster=~"$cluster",instance=~"$instance",job="kube-controller-manager"}
+                                seriesNameFormat: '{{quantile}} - {{pod}}'
+    layouts:
+        - kind: Grid
+          spec:
+            display:
+                title: Controller Manager Status
+            items:
+                - x: 0
+                  "y": 0
+                  width: 24
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/0_0'
+        - kind: Grid
+          spec:
+            display:
+                title: Work Queue
+            items:
+                - x: 0
+                  "y": 0
+                  width: 8
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/1_0'
+                - x: 8
+                  "y": 0
+                  width: 8
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/1_1'
+                - x: 16
+                  "y": 0
+                  width: 8
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/1_2'
+        - kind: Grid
+          spec:
+            display:
+                title: Kube API Requests
+            items:
+                - x: 0
+                  "y": 0
+                  width: 8
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/2_0'
+                - x: 8
+                  "y": 0
+                  width: 8
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/2_1'
+                - x: 16
+                  "y": 0
+                  width: 8
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/2_2'
+        - kind: Grid
+          spec:
+            display:
+                title: Resource Usage
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/3_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/3_1'
+                - x: 0
+                  "y": 8
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/3_2'
+                - x: 12
+                  "y": 8
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/3_3'
+    duration: 1h

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/perses/community-dashboards/pkg/dashboards/alertmanager"
 	"github.com/perses/community-dashboards/pkg/dashboards/blackbox"
 	k8sComputeResources "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/compute_resources"
+	controller_manager "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/controller_manager"
 	kubelet "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/kubelet"
 	k8sNetworking "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/networking"
 	k8sPersistentVolume "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/persistent_volume"
@@ -51,6 +52,7 @@ func main() {
 	dashboardWriter.Add(k8sComputeResources.BuildKubernetesWorkloadNamespaceOverview(project, datasource, clusterLabelName))
 	dashboardWriter.Add(k8sComputeResources.BuildKubernetesMultiClusterOverview(project, datasource, clusterLabelName))
 	dashboardWriter.Add(kubelet.BuildKubeletOverview(project, datasource, clusterLabelName))
+	dashboardWriter.Add(controller_manager.BuildControllerManagerOverview(project, datasource, clusterLabelName))
 	dashboardWriter.Add(k8sNetworking.BuildKubernetesClusterOverview(project, datasource, clusterLabelName))
 	dashboardWriter.Add(k8sNetworking.BuildKubernetesNamespaceByPodOverview(project, datasource, clusterLabelName))
 	dashboardWriter.Add(k8sNetworking.BuildKubernetesNamespaceByWorkloadOverview(project, datasource, clusterLabelName))

--- a/pkg/dashboards/kubernetes/controller_manager/controller_manager.go
+++ b/pkg/dashboards/kubernetes/controller_manager/controller_manager.go
@@ -1,0 +1,101 @@
+package controller_manager
+
+import (
+	"github.com/perses/community-dashboards/pkg/dashboards"
+	panelsGostats "github.com/perses/community-dashboards/pkg/panels/gostats"
+	panels "github.com/perses/community-dashboards/pkg/panels/kubernetes"
+	"github.com/perses/community-dashboards/pkg/promql"
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+)
+
+func withCMStatsGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("Controller Manager Status",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(8),
+		panels.ControllerManagerUpStatus(datasource, labelMatcher),
+	)
+}
+
+func withCMWorkQueueGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("Work Queue",
+		panelgroup.PanelsPerLine(3),
+		panelgroup.PanelHeight(8),
+		panels.WorkQueueAddRate(datasource, labelMatcher),
+		panels.WorkQueueDepth(datasource, labelMatcher),
+		panels.WorkQueueLatency(datasource, labelMatcher),
+	)
+}
+
+func withCMKubeAPIRequestsGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("Kube API Requests",
+		panelgroup.PanelsPerLine(3),
+		panelgroup.PanelHeight(8),
+		panels.KubeAPIRequestRate(datasource, labelMatcher),
+		panels.PostRequestLatency(datasource, labelMatcher),
+		panels.GetRequestLatency(datasource, labelMatcher),
+	)
+}
+
+func withCMResources(datasource string, clusterLabelMatcher promql.LabelMatcher) dashboard.Option {
+	// TODO(saswatamcode): Add a way to configure these.
+	labelMatchersToUse := []promql.LabelMatcher{
+		promql.ClusterVar,
+		promql.InstanceVar,
+		{
+			Name:  "job",
+			Value: "kube-controller-manager",
+			Type:  "=",
+		},
+	}
+
+	labelMatchersToUse = append(labelMatchersToUse, clusterLabelMatcher)
+
+	return dashboard.AddPanelGroup("Resource Usage",
+		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
+		panelsGostats.MemoryUsage(datasource, labelMatchersToUse...),
+		panels.KubeletCPU(datasource, labelMatchersToUse...),
+		panelsGostats.Goroutines(datasource, labelMatchersToUse...),
+		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, labelMatchersToUse...),
+	)
+}
+
+func BuildControllerManagerOverview(project string, datasource string, clusterLabelName string) dashboards.DashboardResult {
+	clusterLabelMatcher := dashboards.GetClusterLabelMatcher(clusterLabelName)
+	return dashboards.NewDashboardResult(
+		dashboard.New("controller-manager-overview",
+			dashboard.ProjectName(project),
+			dashboard.Name("Kubernetes / Controller Manager"),
+			dashboard.AddVariable("cluster",
+				listVar.List(
+					labelValuesVar.PrometheusLabelValues("cluster",
+						labelValuesVar.Matchers("up{"+panels.GetControllerManagerMatcher()+"}"),
+						dashboards.AddVariableDatasource(datasource),
+					),
+					listVar.DisplayName("cluster"),
+				),
+			),
+			dashboard.AddVariable("instance",
+				listVar.List(
+					labelValuesVar.PrometheusLabelValues("instance",
+						labelValuesVar.Matchers(
+							promql.SetLabelMatchers(
+								"up{"+panels.GetControllerManagerMatcher()+"}",
+								[]promql.LabelMatcher{{Name: "cluster", Type: "=", Value: "$cluster"}},
+							),
+						),
+						dashboards.AddVariableDatasource(datasource),
+					),
+					listVar.DisplayName("instance"),
+				),
+			),
+			withCMStatsGroup(datasource, clusterLabelMatcher),
+			withCMWorkQueueGroup(datasource, clusterLabelMatcher),
+			withCMKubeAPIRequestsGroup(datasource, clusterLabelMatcher),
+			withCMResources(datasource, clusterLabelMatcher),
+		),
+	).Component("kubernetes")
+}

--- a/pkg/dashboards/kubernetes/kubelet/kubelet.go
+++ b/pkg/dashboards/kubernetes/kubelet/kubelet.go
@@ -99,6 +99,7 @@ func withRequestDurationQuantile(datasource string, labelMatcher promql.LabelMat
 }
 
 func withKubeletResources(datasource string, clusterLabelMatcher promql.LabelMatcher) dashboard.Option {
+	// TODO(saswatamcode): Add a way to configure these.
 	labelMatchersToUse := []promql.LabelMatcher{
 		promql.ClusterVar,
 		promql.InstanceVar,

--- a/pkg/panels/kubernetes/controller_manager.go
+++ b/pkg/panels/kubernetes/controller_manager.go
@@ -1,0 +1,276 @@
+package kubernetes
+
+import (
+	"github.com/perses/community-dashboards/pkg/dashboards"
+	"github.com/perses/community-dashboards/pkg/promql"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+func ControllerManagerUpStatus(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Up",
+		panel.Description("Shows the status of the controller manager."),
+		statPanel.Chart(
+			statPanel.Format(commonSdk.Format{
+				Unit:          string(commonSdk.DecimalUnit),
+				DecimalPlaces: 0,
+			}),
+			statPanel.ValueFontSize(50),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(up{cluster=\"$cluster\", job=\"kube-controller-manager\"})",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+			),
+		),
+	)
+}
+
+func WorkQueueAddRate(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Work Queue Add Rate",
+		panel.Description("Shows the rate of work queue add events."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.DecimalUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.ListMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(workqueue_adds_total{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, name)",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{cluster}} {{instance}} {{name}}"),
+			),
+		),
+	)
+}
+
+func WorkQueueDepth(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Work Queue Depth",
+		panel.Description("Shows the depth of the work queue."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.DecimalUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.ListMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(workqueue_depth{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, name)",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{cluster}} {{instance}} {{name}}"),
+			),
+		),
+	)
+}
+
+func WorkQueueLatency(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Work Queue Latency",
+		panel.Description("Shows the 99th percentile latency of items queued in the work queue."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.SecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.ListMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"histogram_quantile(0.99, sum(rate(workqueue_queue_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\"}[$__rate_interval])) by (cluster, instance, name, le))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{cluster}} {{instance}} {{name}}"),
+			),
+		),
+	)
+}
+
+func KubeAPIRequestRate(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Kube API Request Rate",
+		panel.Description("Shows the rate of requests to the Kube API."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.RequestsPerSecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.ListMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Stack:        timeSeriesPanel.AllStack,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"2..\"}[$__rate_interval]))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("2xx"),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"3..\"}[$__rate_interval]))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("3xx"),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"4..\"}[$__rate_interval]))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("4xx"),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(rest_client_requests_total{job=\"kube-controller-manager\", instance=~\"$instance\",code=~\"5..\"}[$__rate_interval]))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("5xx"),
+			),
+		),
+	)
+}
+
+func PostRequestLatency(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Post Request Latency 99th Quantile",
+		panel.Description("Shows the 99th quantile latency of post requests to the Kube API."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.SecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.ListMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"POST\"}[$__rate_interval])) by (verb, le))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{verb}}"),
+			),
+		),
+	)
+}
+
+func GetRequestLatency(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Get Request Latency 99th Quantile",
+		panel.Description("Shows the 99th quantile latency of get requests to the Kube API."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.SecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.ListMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"histogram_quantile(0.99, sum(rate(rest_client_request_duration_seconds_bucket{cluster=\"$cluster\", job=\"kube-controller-manager\", instance=~\"$instance\", verb=\"GET\"}[$__rate_interval])) by (verb, le))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{verb}}"),
+			),
+		),
+	)
+}

--- a/pkg/panels/kubernetes/globals.go
+++ b/pkg/panels/kubernetes/globals.go
@@ -6,6 +6,7 @@ var (
 	KUBE_STATE_METRICS_MATCHER = "job=\"kube-state-metrics\""
 	KUBELET_MATCHER            = "job=\"kubelet\""
 	NODE_EXPORTER_MATCHER      = "job=\"node-exporter\""
+	CONTROLLER_MANAGER_MATCHER = "job=\"kube-controller-manager\""
 )
 
 // GetCAdvisorMatcher returns the matcher for the cadvisor job.
@@ -28,6 +29,11 @@ func GetNodeExporterMatcher() string {
 	return NODE_EXPORTER_MATCHER
 }
 
+// GetControllerManagerMatcher returns the matcher for the controller-manager job.
+func GetControllerManagerMatcher() string {
+	return CONTROLLER_MANAGER_MATCHER
+}
+
 // SetCAdvisorMatcher sets the matcher for the cadvisor job globally.
 func SetCAdvisorMatcher(matcher string) {
 	CADVISOR_MATCHER = matcher
@@ -46,6 +52,11 @@ func SetKubeletMatcher(matcher string) {
 // SetNodeExporterMatcher sets the matcher for the node-exporter job globally.
 func SetNodeExporterMatcher(matcher string) {
 	NODE_EXPORTER_MATCHER = matcher
+}
+
+// SetControllerManagerMatcher sets the matcher for the controller-manager job globally.
+func SetControllerManagerMatcher(matcher string) {
+	CONTROLLER_MANAGER_MATCHER = matcher
 }
 
 // Metrics deprecation considerations: https://github.com/kubernetes-monitoring/kubernetes-mixin?tab=readme-ov-file#metrics-deprecation


### PR DESCRIPTION
This commit adds the kubernetes-mixin dashboard for controller manager.

Couldn't try on a local-cluster, but tried on an openshift one, and it works!

![Screenshot 2025-05-13 at 10 16 11](https://github.com/user-attachments/assets/ee26ec50-46eb-4232-9223-2f6f35593d86)
![Screenshot 2025-05-13 at 10 16 18](https://github.com/user-attachments/assets/20abdd13-a508-4451-bc97-1e0f3517d9b9)
