### PR TITLE
Fix units on seconds_ histogram metrics

### DIFF
--- a/examples/dashboards/operator/kubernetes/controller-manager-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/controller-manager-overview.yaml
@@ -603,7 +603,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/kubernetes/kubelet-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubelet-overview.yaml
@@ -1248,7 +1248,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/perses/perses-overview.yaml
+++ b/examples/dashboards/operator/perses/perses-overview.yaml
@@ -229,7 +229,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -432,7 +432,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos/thanos-compact-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-compact-overview.yaml
@@ -533,7 +533,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -691,7 +691,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -955,7 +955,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1149,7 +1149,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1389,7 +1389,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-query-frontend-overview.yaml
@@ -240,7 +240,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -624,7 +624,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos/thanos-query-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-query-overview.yaml
@@ -265,7 +265,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -425,7 +425,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -584,7 +584,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -745,7 +745,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1099,7 +1099,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos/thanos-receive-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-receive-overview.yaml
@@ -381,7 +381,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -542,7 +542,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1068,7 +1068,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1227,7 +1227,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1388,7 +1388,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1753,7 +1753,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos/thanos-ruler-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-ruler-overview.yaml
@@ -455,7 +455,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -719,7 +719,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -880,7 +880,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1120,7 +1120,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/operator/thanos/thanos-store-overview.yaml
+++ b/examples/dashboards/operator/thanos/thanos-store-overview.yaml
@@ -337,7 +337,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -498,7 +498,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -656,7 +656,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1416,7 +1416,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1493,7 +1493,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1570,7 +1570,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -1905,7 +1905,7 @@ spec:
                 mode: auto
             yAxis:
               format:
-                unit: milliseconds
+                unit: seconds
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/perses/kubernetes/controller-manager-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/controller-manager-overview.yaml
@@ -537,7 +537,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/kubernetes/kubelet-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubelet-overview.yaml
@@ -1058,7 +1058,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/perses/perses-overview.yaml
+++ b/examples/dashboards/perses/perses/perses-overview.yaml
@@ -172,7 +172,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -375,7 +375,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/thanos/thanos-compact-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-compact-overview.yaml
@@ -350,7 +350,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -506,7 +506,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -766,7 +766,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -957,7 +957,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -1197,7 +1197,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/thanos/thanos-query-frontend-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-query-frontend-overview.yaml
@@ -174,7 +174,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -558,7 +558,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/thanos/thanos-query-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-query-overview.yaml
@@ -138,7 +138,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -296,7 +296,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -454,7 +454,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -612,7 +612,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -964,7 +964,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/thanos/thanos-receive-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-receive-overview.yaml
@@ -157,7 +157,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -317,7 +317,7 @@ spec:
                             mode: list
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -841,7 +841,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -999,7 +999,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -1157,7 +1157,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -1522,7 +1522,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/thanos/thanos-ruler-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-ruler-overview.yaml
@@ -318,7 +318,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -580,7 +580,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -738,7 +738,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -978,7 +978,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/examples/dashboards/perses/thanos/thanos-store-overview.yaml
+++ b/examples/dashboards/perses/thanos/thanos-store-overview.yaml
@@ -140,7 +140,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -298,7 +298,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -454,7 +454,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -1208,7 +1208,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -1284,7 +1284,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -1360,7 +1360,7 @@ spec:
                             mode: table
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25
@@ -1693,7 +1693,7 @@ spec:
                                 - last
                         yAxis:
                             format:
-                                unit: milliseconds
+                                unit: seconds
                         visual:
                             display: line
                             lineWidth: 0.25

--- a/pkg/panels/gostats/gostats.go
+++ b/pkg/panels/gostats/gostats.go
@@ -148,7 +148,7 @@ func GarbageCollectionPauseTimeQuantiles(datasourceName string, seriesNameToUse 
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/perses/perses.go
+++ b/pkg/panels/perses/perses.go
@@ -61,7 +61,7 @@ func HTTPRequestsLatencyPanel(datasourceName string, labelMatchers ...promql.Lab
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &common.Format{
-					Unit: string(common.MilliSecondsUnit),
+					Unit: string(common.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/thanos/common.go
+++ b/pkg/panels/thanos/common.go
@@ -88,7 +88,7 @@ func BucketOperationDurations(datasourceName string, labelMatchers ...promql.Lab
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -212,7 +212,7 @@ func ReadGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Label
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -336,7 +336,7 @@ func ReadGPRCStreamDurations(datasourceName string, labelMatchers ...promql.Labe
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/thanos/thanos_compact.go
+++ b/pkg/panels/thanos/thanos_compact.go
@@ -158,7 +158,7 @@ func DownsampleDurations(datasourceName string, labelMatchers ...promql.LabelMat
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -282,7 +282,7 @@ func SyncMetaDurations(datasourceName string, labelMatchers ...promql.LabelMatch
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -511,7 +511,7 @@ func GarbageCollectionDurations(datasourceName string, labelMatchers ...promql.L
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/thanos/thanos_query.go
+++ b/pkg/panels/thanos/thanos_query.go
@@ -88,7 +88,7 @@ func InstantQueryRequestDurations(datasourceName string, labelMatchers ...promql
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -212,7 +212,7 @@ func RangeQueryRequestDurations(datasourceName string, labelMatchers ...promql.L
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/thanos/thanos_query_frontend.go
+++ b/pkg/panels/thanos/thanos_query_frontend.go
@@ -123,7 +123,7 @@ func QueryFrontendDurations(datasourceName string, labelMatchers ...promql.Label
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/thanos/thanos_receive.go
+++ b/pkg/panels/thanos/thanos_receive.go
@@ -88,7 +88,7 @@ func RemoteWriteRequestDurations(datasourceName string, labelMatchers ...promql.
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -210,7 +210,7 @@ func TenantedRemoteWriteRequestDurations(datasourceName string, labelMatchers ..
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -667,7 +667,7 @@ func WriteGPRCUnaryDurations(datasourceName string, labelMatchers ...promql.Labe
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/thanos/thanos_ruler.go
+++ b/pkg/panels/thanos/thanos_ruler.go
@@ -265,7 +265,7 @@ func AlertSendingDurations(datasourceName string, labelMatchers ...promql.LabelM
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{

--- a/pkg/panels/thanos/thanos_store.go
+++ b/pkg/panels/thanos/thanos_store.go
@@ -554,7 +554,7 @@ func GetAllSeriesDurations(datasourceName string, labelMatchers ...promql.LabelM
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -608,7 +608,7 @@ func MergeDurations(datasourceName string, labelMatchers ...promql.LabelMatcher)
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
@@ -662,7 +662,7 @@ func GateWaitingDurations(datasourceName string, labelMatchers ...promql.LabelMa
 		timeSeriesPanel.Chart(
 			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
 				Format: &commonSdk.Format{
-					Unit: string(commonSdk.MilliSecondsUnit),
+					Unit: string(commonSdk.SecondsUnit),
 				},
 			}),
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{


### PR DESCRIPTION
This commit fixes quantile panels for which metrics are nearly always in seconds unit.