### PR TITLE
feat: Add etcd overview dashboard from etcd-mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Welcome to the **Perses Community Dashboards** repository! This project is desig
 - Scheduler
 - Proxy
 
+### etcd-mixin Dashboards
+- etcd Overview
+
 ### Blackbox Exporter
 - Blackbox Exporter Overview
 

--- a/examples/dashboards/json/operator/etcd/etcd-overview.json
+++ b/examples/dashboards/json/operator/etcd/etcd-overview.json
@@ -1,0 +1,1149 @@
+{
+  "kind": "PersesDashboard",
+  "apiVersion": "perses.dev/v1alpha1",
+  "metadata": {
+    "name": "etcd-overview",
+    "namespace": "perses-dev",
+    "creationTimestamp": null,
+    "labels": {
+      "app.kubernetes.io/component": "dashboard",
+      "app.kubernetes.io/instance": "etcd-overview",
+      "app.kubernetes.io/name": "perses-dashboard",
+      "app.kubernetes.io/part-of": "perses-operator"
+    }
+  },
+  "spec": {
+    "display": {
+      "name": "etcd Overview"
+    },
+    "variables": [
+      {
+        "kind": "ListVariable",
+        "spec": {
+          "display": {
+            "name": "cluster",
+            "hidden": false
+          },
+          "allowAllValue": false,
+          "allowMultiple": false,
+          "plugin": {
+            "kind": "PrometheusLabelValuesVariable",
+            "spec": {
+              "datasource": {
+                "kind": "PrometheusDatasource",
+                "name": "prometheus-datasource"
+              },
+              "labelName": "cluster",
+              "matchers": [
+                "etcd_server_has_leader{job=~\".*etcd.*\"}"
+              ]
+            }
+          },
+          "name": "cluster"
+        }
+      }
+    ],
+    "panels": {
+      "0_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Up",
+            "description": "Shows the status of etcd."
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "last",
+              "format": {
+                "unit": "decimal"
+              },
+              "valueFontSize": 50
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "sum(etcd_server_has_leader{cluster=\"$cluster\",job=~\".*etcd.*\"})",
+                    "seriesNameFormat": "{{cluster}} {{namespace}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "RPC Rate",
+            "description": "Shows the rate of gRPC requests."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "ops/sec"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 1,
+                "palette": {
+                  "mode": "auto"
+                },
+                "stack": "all"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "sum(\n  rate(grpc_server_started_total{cluster=\"$cluster\",grpc_type=\"unary\",job=~\".*etcd.*\"}[$__rate_interval])\n)",
+                    "seriesNameFormat": "RPC Rate"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "sum(\n  rate(\n    grpc_server_handled_total{cluster=\"$cluster\",grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\",grpc_type=\"unary\",job=~\".*etcd.*\"}[$__rate_interval]\n  )\n)",
+                    "seriesNameFormat": "RPC failed Rate"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "1_1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Active Streams",
+            "description": "Shows the number of active streams."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 1,
+                "palette": {
+                  "mode": "auto"
+                },
+                "stack": "all"
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "  sum(\n    grpc_server_started_total{cluster=\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\",job=~\".*etcd.*\"}\n  )\n-\n  sum(\n    grpc_server_handled_total{cluster=\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}\n  )",
+                    "seriesNameFormat": "Watch Streams"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "  sum(\n    grpc_server_started_total{cluster=\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\",job=~\".*etcd.*\"}\n  )\n-\n  sum(\n    grpc_server_handled_total{cluster=\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}\n  )",
+                    "seriesNameFormat": "Lease Streams"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "DB Size",
+            "description": "Shows the size of the etcd database."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "etcd_mvcc_db_total_size_in_bytes{cluster=\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "{{instance}} DB Size"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "2_1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Disk Sync Duration",
+            "description": "Shows the duration of the etcd disk sync for WAL and DB."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "histogram_quantile(\n  0.99,\n  sum by (instance, le) (\n    rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])\n  )\n)",
+                    "seriesNameFormat": "{{instance}} WAL fsync"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "histogram_quantile(\n  0.99,\n  sum by (instance, le) (\n    rate(\n      etcd_disk_backend_commit_duration_seconds_bucket{cluster=\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval]\n    )\n  )\n)",
+                    "seriesNameFormat": "{{instance}} DB fsync"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "3_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Raft Proposals / Leader Elections in a day",
+            "description": "Shows the number of times etcd has leader elections in a day."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "changes(etcd_server_leader_changes_seen_total{cluster=\"$cluster\",job=~\".*etcd.*\"}[1d])",
+                    "seriesNameFormat": "{{instance}} total leader elections per day"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Client Traffic In",
+            "description": "Shows the client traffic into etcd."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "rate(etcd_network_client_grpc_received_bytes_total{cluster=\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])",
+                    "seriesNameFormat": "{{instance}} client traffic in"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4_1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Client Traffic Out",
+            "description": "Shows the client traffic out of etcd."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "rate(etcd_network_client_grpc_sent_bytes_total{cluster=\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])",
+                    "seriesNameFormat": "{{instance}} client traffic out"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4_2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Peer Traffic In",
+            "description": "Shows the peer traffic into etcd."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "sum by (instance) (\n  rate(etcd_network_peer_received_bytes_total{cluster=\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])\n)",
+                    "seriesNameFormat": "{{instance}} peer traffic in"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "4_3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Peer Traffic Out",
+            "description": "Shows the peer traffic out of etcd."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes/sec"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "sum by (instance) (\n  rate(etcd_network_peer_sent_bytes_total{cluster=\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])\n)",
+                    "seriesNameFormat": "{{instance}} peer traffic out"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "5_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Peer Roundtrip Time",
+            "description": "Shows the roundtrip time of the peer traffic."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "size": "small"
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "histogram_quantile(\n  0.99,\n  sum by (instance, le) (\n    rate(\n      etcd_network_peer_round_trip_time_seconds_bucket{cluster=\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval]\n    )\n  )\n)",
+                    "seriesNameFormat": "{{instance}} peer roundtrip time"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6_0": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Memory Usage",
+            "description": "Shows various memory usage metrics of the component."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "values": [
+                  "last"
+                ]
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "bytes"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "go_memstats_alloc_bytes{cluster=~\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "Alloc All {{instance}}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "go_memstats_heap_alloc_bytes{cluster=~\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "Alloc Heap {{instance}}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "rate(go_memstats_alloc_bytes_total{cluster=~\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])",
+                    "seriesNameFormat": "Alloc Rate All {{instance}}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "rate(go_memstats_heap_alloc_bytes{cluster=~\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])",
+                    "seriesNameFormat": "Alloc Rate Heap {{instance}}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "go_memstats_stack_inuse_bytes{cluster=~\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "Inuse Stack {{instance}}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "go_memstats_heap_inuse_bytes{cluster=~\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "Inuse Heap {{instance}}"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "process_resident_memory_bytes{cluster=~\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "Resident Memory {{instance}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6_1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "CPU Usage",
+            "description": "Shows the CPU usage of the component."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "values": [
+                  "last"
+                ]
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "rate(process_cpu_seconds_total{cluster=~\"$cluster\",job=~\".*etcd.*\"}[$__rate_interval])",
+                    "seriesNameFormat": "{{instance}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6_2": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "Goroutines",
+            "description": "Shows the number of goroutines being used by the component."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "values": [
+                  "last"
+                ]
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "decimal"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "go_goroutines{cluster=~\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "{{instance}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      },
+      "6_3": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "GC Duration",
+            "description": "Shows the Go garbage collection pause durations for the component."
+          },
+          "plugin": {
+            "kind": "TimeSeriesChart",
+            "spec": {
+              "legend": {
+                "position": "bottom",
+                "mode": "table",
+                "values": [
+                  "last"
+                ]
+              },
+              "yAxis": {
+                "format": {
+                  "unit": "seconds"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
+                }
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "datasource": {
+                      "kind": "PrometheusDatasource",
+                      "name": "prometheus-datasource"
+                    },
+                    "query": "go_gc_duration_seconds{cluster=~\"$cluster\",job=~\".*etcd.*\"}",
+                    "seriesNameFormat": "{{quantile}} - {{instance}}"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "layouts": [
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "etcd Status"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/0_0"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "RPC and Streams"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/1_0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/1_1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "etcd DB"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/2_0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/2_1"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "etcd Raft"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/3_0"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "etcd Traffic"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4_0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4_1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4_2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/4_3"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "etcd Peer Round Trip Time"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 24,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/5_0"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "Grid",
+        "spec": {
+          "display": {
+            "title": "Resource Usage"
+          },
+          "items": [
+            {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6_0"
+              }
+            },
+            {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6_1"
+              }
+            },
+            {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6_2"
+              }
+            },
+            {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "content": {
+                "$ref": "#/spec/panels/6_3"
+              }
+            }
+          ]
+        }
+      }
+    ],
+    "duration": "1h"
+  },
+  "status": {}
+}

--- a/examples/dashboards/operator/etcd/etcd-overview.yaml
+++ b/examples/dashboards/operator/etcd/etcd-overview.yaml
@@ -1,0 +1,793 @@
+apiVersion: perses.dev/v1alpha1
+kind: PersesDashboard
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: dashboard
+    app.kubernetes.io/instance: etcd-overview
+    app.kubernetes.io/name: perses-dashboard
+    app.kubernetes.io/part-of: perses-operator
+  name: etcd-overview
+  namespace: perses-dev
+spec:
+  display:
+    name: etcd Overview
+  duration: 1h
+  layouts:
+  - kind: Grid
+    spec:
+      display:
+        title: etcd Status
+      items:
+      - content:
+          $ref: '#/spec/panels/0_0'
+        height: 8
+        width: 24
+        x: 0
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: RPC and Streams
+      items:
+      - content:
+          $ref: '#/spec/panels/1_0'
+        height: 8
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/1_1'
+        height: 8
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: etcd DB
+      items:
+      - content:
+          $ref: '#/spec/panels/2_0'
+        height: 8
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/2_1'
+        height: 8
+        width: 12
+        x: 12
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: etcd Raft
+      items:
+      - content:
+          $ref: '#/spec/panels/3_0'
+        height: 8
+        width: 24
+        x: 0
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: etcd Traffic
+      items:
+      - content:
+          $ref: '#/spec/panels/4_0'
+        height: 8
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/4_1'
+        height: 8
+        width: 12
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/4_2'
+        height: 8
+        width: 12
+        x: 0
+        "y": 8
+      - content:
+          $ref: '#/spec/panels/4_3'
+        height: 8
+        width: 12
+        x: 12
+        "y": 8
+  - kind: Grid
+    spec:
+      display:
+        title: etcd Peer Round Trip Time
+      items:
+      - content:
+          $ref: '#/spec/panels/5_0'
+        height: 8
+        width: 24
+        x: 0
+        "y": 0
+  - kind: Grid
+    spec:
+      display:
+        title: Resource Usage
+      items:
+      - content:
+          $ref: '#/spec/panels/6_0'
+        height: 8
+        width: 12
+        x: 0
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/6_1'
+        height: 8
+        width: 12
+        x: 12
+        "y": 0
+      - content:
+          $ref: '#/spec/panels/6_2'
+        height: 8
+        width: 12
+        x: 0
+        "y": 8
+      - content:
+          $ref: '#/spec/panels/6_3'
+        height: 8
+        width: 12
+        x: 12
+        "y": 8
+  panels:
+    "0_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the status of etcd.
+          name: Up
+        plugin:
+          kind: StatChart
+          spec:
+            calculation: last
+            format:
+              unit: decimal
+            valueFontSize: 50
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: sum(etcd_server_has_leader{cluster="$cluster",job=~".*etcd.*"})
+                seriesNameFormat: '{{cluster}} {{namespace}}'
+    "1_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the rate of gRPC requests.
+          name: RPC Rate
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+              stack: all
+            yAxis:
+              format:
+                unit: ops/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum(
+                    rate(grpc_server_started_total{cluster="$cluster",grpc_type="unary",job=~".*etcd.*"}[$__rate_interval])
+                  )
+                seriesNameFormat: RPC Rate
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum(
+                    rate(
+                      grpc_server_handled_total{cluster="$cluster",grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",grpc_type="unary",job=~".*etcd.*"}[$__rate_interval]
+                    )
+                  )
+                seriesNameFormat: RPC failed Rate
+    "1_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the number of active streams.
+          name: Active Streams
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+              stack: all
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    sum(
+                      grpc_server_started_total{cluster="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream",job=~".*etcd.*"}
+                    )
+                  -
+                    sum(
+                      grpc_server_handled_total{cluster="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+                    )
+                seriesNameFormat: Watch Streams
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |2-
+                    sum(
+                      grpc_server_started_total{cluster="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream",job=~".*etcd.*"}
+                    )
+                  -
+                    sum(
+                      grpc_server_handled_total{cluster="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+                    )
+                seriesNameFormat: Lease Streams
+    "2_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the size of the etcd database.
+          name: DB Size
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: bytes
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: etcd_mvcc_db_total_size_in_bytes{cluster="$cluster",job=~".*etcd.*"}
+                seriesNameFormat: '{{instance}} DB Size'
+    "2_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the duration of the etcd disk sync for WAL and DB.
+          name: Disk Sync Duration
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.99,
+                    sum by (instance, le) (
+                      rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                    )
+                  )
+                seriesNameFormat: '{{instance}} WAL fsync'
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.99,
+                    sum by (instance, le) (
+                      rate(
+                        etcd_disk_backend_commit_duration_seconds_bucket{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval]
+                      )
+                    )
+                  )
+                seriesNameFormat: '{{instance}} DB fsync'
+    "3_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the number of times etcd has leader elections in a day.
+          name: Raft Proposals / Leader Elections in a day
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: changes(etcd_server_leader_changes_seen_total{cluster="$cluster",job=~".*etcd.*"}[1d])
+                seriesNameFormat: '{{instance}} total leader elections per day'
+    "4_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the client traffic into etcd.
+          name: Client Traffic In
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(etcd_network_client_grpc_received_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                seriesNameFormat: '{{instance}} client traffic in'
+    "4_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the client traffic out of etcd.
+          name: Client Traffic Out
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(etcd_network_client_grpc_sent_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                seriesNameFormat: '{{instance}} client traffic out'
+    "4_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the peer traffic into etcd.
+          name: Peer Traffic In
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (instance) (
+                    rate(etcd_network_peer_received_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                  )
+                seriesNameFormat: '{{instance}} peer traffic in'
+    "4_3":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the peer traffic out of etcd.
+          name: Peer Traffic Out
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: bytes/sec
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  sum by (instance) (
+                    rate(etcd_network_peer_sent_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                  )
+                seriesNameFormat: '{{instance}} peer traffic out'
+    "5_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the roundtrip time of the peer traffic.
+          name: Peer Roundtrip Time
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: |-
+                  histogram_quantile(
+                    0.99,
+                    sum by (instance, le) (
+                      rate(
+                        etcd_network_peer_round_trip_time_seconds_bucket{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval]
+                      )
+                    )
+                  )
+                seriesNameFormat: '{{instance}} peer roundtrip time'
+    "6_0":
+      kind: Panel
+      spec:
+        display:
+          description: Shows various memory usage metrics of the component.
+          name: Memory Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: bytes
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_alloc_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                seriesNameFormat: Alloc All {{instance}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                seriesNameFormat: Alloc Heap {{instance}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(go_memstats_alloc_bytes_total{cluster=~"$cluster",job=~".*etcd.*"}[$__rate_interval])
+                seriesNameFormat: Alloc Rate All {{instance}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(go_memstats_heap_alloc_bytes{cluster=~"$cluster",job=~".*etcd.*"}[$__rate_interval])
+                seriesNameFormat: Alloc Rate Heap {{instance}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                seriesNameFormat: Inuse Stack {{instance}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                seriesNameFormat: Inuse Heap {{instance}}
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: process_resident_memory_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                seriesNameFormat: Resident Memory {{instance}}
+    "6_1":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the CPU usage of the component.
+          name: CPU Usage
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: rate(process_cpu_seconds_total{cluster=~"$cluster",job=~".*etcd.*"}[$__rate_interval])
+                seriesNameFormat: '{{instance}}'
+    "6_2":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the number of goroutines being used by the component.
+          name: Goroutines
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: decimal
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_goroutines{cluster=~"$cluster",job=~".*etcd.*"}
+                seriesNameFormat: '{{instance}}'
+    "6_3":
+      kind: Panel
+      spec:
+        display:
+          description: Shows the Go garbage collection pause durations for the component.
+          name: GC Duration
+        plugin:
+          kind: TimeSeriesChart
+          spec:
+            legend:
+              mode: table
+              position: bottom
+              values:
+              - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+            yAxis:
+              format:
+                unit: seconds
+        queries:
+        - kind: TimeSeriesQuery
+          spec:
+            plugin:
+              kind: PrometheusTimeSeriesQuery
+              spec:
+                datasource:
+                  kind: PrometheusDatasource
+                  name: prometheus-datasource
+                query: go_gc_duration_seconds{cluster=~"$cluster",job=~".*etcd.*"}
+                seriesNameFormat: '{{quantile}} - {{instance}}'
+  variables:
+  - kind: ListVariable
+    spec:
+      allowAllValue: false
+      allowMultiple: false
+      display:
+        hidden: false
+        name: cluster
+      name: cluster
+      plugin:
+        kind: PrometheusLabelValuesVariable
+        spec:
+          datasource:
+            kind: PrometheusDatasource
+            name: prometheus-datasource
+          labelName: cluster
+          matchers:
+          - etcd_server_has_leader{job=~".*etcd.*"}
+status: {}

--- a/examples/dashboards/perses/etcd/etcd-overview.yaml
+++ b/examples/dashboards/perses/etcd/etcd-overview.yaml
@@ -1,0 +1,788 @@
+kind: Dashboard
+metadata:
+    name: etcd-overview
+    createdAt: 0001-01-01T00:00:00Z
+    updatedAt: 0001-01-01T00:00:00Z
+    version: 0
+    project: perses-dev
+spec:
+    display:
+        name: etcd Overview
+    variables:
+        - kind: ListVariable
+          spec:
+            display:
+                name: cluster
+                hidden: false
+            allowAllValue: false
+            allowMultiple: false
+            plugin:
+                kind: PrometheusLabelValuesVariable
+                spec:
+                    datasource:
+                        kind: PrometheusDatasource
+                        name: prometheus-datasource
+                    labelName: cluster
+                    matchers:
+                        - etcd_server_has_leader{job=~".*etcd.*"}
+            name: cluster
+    panels:
+        "0_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Up
+                    description: Shows the status of etcd.
+                plugin:
+                    kind: StatChart
+                    spec:
+                        calculation: last
+                        format:
+                            unit: decimal
+                        valueFontSize: 50
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: sum(etcd_server_has_leader{cluster="$cluster",job=~".*etcd.*"})
+                                seriesNameFormat: '{{cluster}} {{namespace}}'
+        "1_0":
+            kind: Panel
+            spec:
+                display:
+                    name: RPC Rate
+                    description: Shows the rate of gRPC requests.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: ops/sec
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
+                            stack: all
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum(
+                                      rate(grpc_server_started_total{cluster="$cluster",grpc_type="unary",job=~".*etcd.*"}[$__rate_interval])
+                                    )
+                                seriesNameFormat: RPC Rate
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum(
+                                      rate(
+                                        grpc_server_handled_total{cluster="$cluster",grpc_code=~"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",grpc_type="unary",job=~".*etcd.*"}[$__rate_interval]
+                                      )
+                                    )
+                                seriesNameFormat: RPC failed Rate
+        "1_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Active Streams
+                    description: Shows the number of active streams.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
+                            stack: all
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      sum(
+                                        grpc_server_started_total{cluster="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream",job=~".*etcd.*"}
+                                      )
+                                    -
+                                      sum(
+                                        grpc_server_handled_total{cluster="$cluster",grpc_service="etcdserverpb.Watch",grpc_type="bidi_stream"}
+                                      )
+                                seriesNameFormat: Watch Streams
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |4-
+                                      sum(
+                                        grpc_server_started_total{cluster="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream",job=~".*etcd.*"}
+                                      )
+                                    -
+                                      sum(
+                                        grpc_server_handled_total{cluster="$cluster",grpc_service="etcdserverpb.Lease",grpc_type="bidi_stream"}
+                                      )
+                                seriesNameFormat: Lease Streams
+        "2_0":
+            kind: Panel
+            spec:
+                display:
+                    name: DB Size
+                    description: Shows the size of the etcd database.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: bytes
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: etcd_mvcc_db_total_size_in_bytes{cluster="$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: '{{instance}} DB Size'
+        "2_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Disk Sync Duration
+                    description: Shows the duration of the etcd disk sync for WAL and DB.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.99,
+                                      sum by (instance, le) (
+                                        rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                      )
+                                    )
+                                seriesNameFormat: '{{instance}} WAL fsync'
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.99,
+                                      sum by (instance, le) (
+                                        rate(
+                                          etcd_disk_backend_commit_duration_seconds_bucket{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval]
+                                        )
+                                      )
+                                    )
+                                seriesNameFormat: '{{instance}} DB fsync'
+        "3_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Raft Proposals / Leader Elections in a day
+                    description: Shows the number of times etcd has leader elections in a day.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: changes(etcd_server_leader_changes_seen_total{cluster="$cluster",job=~".*etcd.*"}[1d])
+                                seriesNameFormat: '{{instance}} total leader elections per day'
+        "4_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Client Traffic In
+                    description: Shows the client traffic into etcd.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(etcd_network_client_grpc_received_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                seriesNameFormat: '{{instance}} client traffic in'
+        "4_1":
+            kind: Panel
+            spec:
+                display:
+                    name: Client Traffic Out
+                    description: Shows the client traffic out of etcd.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(etcd_network_client_grpc_sent_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                seriesNameFormat: '{{instance}} client traffic out'
+        "4_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Peer Traffic In
+                    description: Shows the peer traffic into etcd.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (instance) (
+                                      rate(etcd_network_peer_received_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                    )
+                                seriesNameFormat: '{{instance}} peer traffic in'
+        "4_3":
+            kind: Panel
+            spec:
+                display:
+                    name: Peer Traffic Out
+                    description: Shows the peer traffic out of etcd.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: bytes/sec
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    sum by (instance) (
+                                      rate(etcd_network_peer_sent_bytes_total{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                    )
+                                seriesNameFormat: '{{instance}} peer traffic out'
+        "5_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Peer Roundtrip Time
+                    description: Shows the roundtrip time of the peer traffic.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            size: small
+                        yAxis:
+                            format:
+                                unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: |-
+                                    histogram_quantile(
+                                      0.99,
+                                      sum by (instance, le) (
+                                        rate(
+                                          etcd_network_peer_round_trip_time_seconds_bucket{cluster="$cluster",job=~".*etcd.*"}[$__rate_interval]
+                                        )
+                                      )
+                                    )
+                                seriesNameFormat: '{{instance}} peer roundtrip time'
+        "6_0":
+            kind: Panel
+            spec:
+                display:
+                    name: Memory Usage
+                    description: Shows various memory usage metrics of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: bytes
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_alloc_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: Alloc All {{instance}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_heap_alloc_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: Alloc Heap {{instance}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(go_memstats_alloc_bytes_total{cluster=~"$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                seriesNameFormat: Alloc Rate All {{instance}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(go_memstats_heap_alloc_bytes{cluster=~"$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                seriesNameFormat: Alloc Rate Heap {{instance}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_stack_inuse_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: Inuse Stack {{instance}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_memstats_heap_inuse_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: Inuse Heap {{instance}}
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: process_resident_memory_bytes{cluster=~"$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: Resident Memory {{instance}}
+        "6_1":
+            kind: Panel
+            spec:
+                display:
+                    name: CPU Usage
+                    description: Shows the CPU usage of the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: rate(process_cpu_seconds_total{cluster=~"$cluster",job=~".*etcd.*"}[$__rate_interval])
+                                seriesNameFormat: '{{instance}}'
+        "6_2":
+            kind: Panel
+            spec:
+                display:
+                    name: Goroutines
+                    description: Shows the number of goroutines being used by the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: decimal
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_goroutines{cluster=~"$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: '{{instance}}'
+        "6_3":
+            kind: Panel
+            spec:
+                display:
+                    name: GC Duration
+                    description: Shows the Go garbage collection pause durations for the component.
+                plugin:
+                    kind: TimeSeriesChart
+                    spec:
+                        legend:
+                            position: bottom
+                            mode: table
+                            values:
+                                - last
+                        yAxis:
+                            format:
+                                unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
+                queries:
+                    - kind: TimeSeriesQuery
+                      spec:
+                        plugin:
+                            kind: PrometheusTimeSeriesQuery
+                            spec:
+                                datasource:
+                                    kind: PrometheusDatasource
+                                    name: prometheus-datasource
+                                query: go_gc_duration_seconds{cluster=~"$cluster",job=~".*etcd.*"}
+                                seriesNameFormat: '{{quantile}} - {{instance}}'
+    layouts:
+        - kind: Grid
+          spec:
+            display:
+                title: etcd Status
+            items:
+                - x: 0
+                  "y": 0
+                  width: 24
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/0_0'
+        - kind: Grid
+          spec:
+            display:
+                title: RPC and Streams
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/1_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/1_1'
+        - kind: Grid
+          spec:
+            display:
+                title: etcd DB
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/2_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/2_1'
+        - kind: Grid
+          spec:
+            display:
+                title: etcd Raft
+            items:
+                - x: 0
+                  "y": 0
+                  width: 24
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/3_0'
+        - kind: Grid
+          spec:
+            display:
+                title: etcd Traffic
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/4_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/4_1'
+                - x: 0
+                  "y": 8
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/4_2'
+                - x: 12
+                  "y": 8
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/4_3'
+        - kind: Grid
+          spec:
+            display:
+                title: etcd Peer Round Trip Time
+            items:
+                - x: 0
+                  "y": 0
+                  width: 24
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/5_0'
+        - kind: Grid
+          spec:
+            display:
+                title: Resource Usage
+            items:
+                - x: 0
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/6_0'
+                - x: 12
+                  "y": 0
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/6_1'
+                - x: 0
+                  "y": 8
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/6_2'
+                - x: 12
+                  "y": 8
+                  width: 12
+                  height: 8
+                  content:
+                    $ref: '#/spec/panels/6_3'
+    duration: 1h

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	dashboards "github.com/perses/community-dashboards/pkg/dashboards"
 	"github.com/perses/community-dashboards/pkg/dashboards/alertmanager"
 	"github.com/perses/community-dashboards/pkg/dashboards/blackbox"
+	"github.com/perses/community-dashboards/pkg/dashboards/etcd"
 	k8sComputeResources "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/compute_resources"
 	controller_manager "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/controller_manager"
 	kubelet "github.com/perses/community-dashboards/pkg/dashboards/kubernetes/kubelet"
@@ -63,6 +64,7 @@ func main() {
 	dashboardWriter.Add(k8sNetworking.BuildKubernetesPodOverview(project, datasource, clusterLabelName))
 	dashboardWriter.Add(k8sNetworking.BuildKubernetesWorkloadOverview(project, datasource, clusterLabelName))
 	dashboardWriter.Add(k8sPersistentVolume.BuildKubernetesPersistentVolumeOverview(project, datasource, clusterLabelName))
+	dashboardWriter.Add(etcd.BuildETCDOverview(project, datasource, clusterLabelName))
 
 	dashboardWriter.Write()
 }

--- a/pkg/dashboards/etcd/etcd.go
+++ b/pkg/dashboards/etcd/etcd.go
@@ -1,0 +1,114 @@
+package etcd
+
+import (
+	"github.com/perses/community-dashboards/pkg/dashboards"
+	panels "github.com/perses/community-dashboards/pkg/panels/etcd"
+	panelsGostats "github.com/perses/community-dashboards/pkg/panels/gostats"
+	"github.com/perses/community-dashboards/pkg/promql"
+	"github.com/perses/perses/go-sdk/dashboard"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	listVar "github.com/perses/perses/go-sdk/variable/list-variable"
+	labelValuesVar "github.com/perses/plugins/prometheus/sdk/go/variable/label-values"
+)
+
+func withETCDStatsGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("etcd Status",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(8),
+		panels.EtcdUpStatus(datasource, labelMatcher),
+	)
+}
+
+func withRPCGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("RPC and Streams",
+		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
+		panels.RPCRate(datasource, labelMatcher),
+		panels.ActiveStreams(datasource, labelMatcher),
+	)
+}
+
+func withDBGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("etcd DB",
+		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
+		panels.DBSize(datasource, labelMatcher),
+		panels.DiskSyncDuration(datasource, labelMatcher),
+	)
+}
+
+func withTrafficGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("etcd Traffic",
+		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
+		panels.ClientTrafficIn(datasource, labelMatcher),
+		panels.ClientTrafficOut(datasource, labelMatcher),
+		panels.PeerTrafficIn(datasource, labelMatcher),
+		panels.PeerTrafficOut(datasource, labelMatcher),
+	)
+}
+
+func withRaftGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("etcd Raft",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(8),
+		panels.RaftProposals(datasource, labelMatcher),
+	)
+}
+
+func withRoundTripTimeGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
+	return dashboard.AddPanelGroup("etcd Peer Round Trip Time",
+		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(8),
+		panels.PeerRoundtripTime(datasource, labelMatcher),
+	)
+}
+
+func withETCDResources(datasource string, clusterLabelMatcher promql.LabelMatcher) dashboard.Option {
+	// TODO(saswatamcode): Add a way to configure these.
+	labelMatchersToUse := []promql.LabelMatcher{
+		promql.ClusterVar,
+		{
+			Name:  "job",
+			Value: ".*etcd.*",
+			Type:  "=~",
+		},
+	}
+
+	labelMatchersToUse = append(labelMatchersToUse, clusterLabelMatcher)
+
+	return dashboard.AddPanelGroup("Resource Usage",
+		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
+		panelsGostats.MemoryUsage(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.CPUUsage(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.Goroutines(datasource, "instance", labelMatchersToUse...),
+		panelsGostats.GarbageCollectionPauseTimeQuantiles(datasource, "instance", labelMatchersToUse...),
+	)
+}
+
+func BuildETCDOverview(project string, datasource string, clusterLabelName string) dashboards.DashboardResult {
+	clusterLabelMatcher := dashboards.GetClusterLabelMatcher(clusterLabelName)
+	return dashboards.NewDashboardResult(
+		dashboard.New("etcd-overview",
+			dashboard.ProjectName(project),
+			dashboard.Name("etcd Overview"),
+			dashboard.AddVariable("cluster",
+				listVar.List(
+					labelValuesVar.PrometheusLabelValues("cluster",
+						labelValuesVar.Matchers("etcd_server_has_leader{job=~\".*etcd.*\"}"),
+						dashboards.AddVariableDatasource(datasource),
+					),
+					listVar.DisplayName("cluster"),
+				),
+			),
+			withETCDStatsGroup(datasource, clusterLabelMatcher),
+			withRPCGroup(datasource, clusterLabelMatcher),
+			withDBGroup(datasource, clusterLabelMatcher),
+			withRaftGroup(datasource, clusterLabelMatcher),
+			withTrafficGroup(datasource, clusterLabelMatcher),
+			withRoundTripTimeGroup(datasource, clusterLabelMatcher),
+			withETCDResources(datasource, clusterLabelMatcher),
+		),
+	).Component("etcd")
+}

--- a/pkg/panels/etcd/etcd.go
+++ b/pkg/panels/etcd/etcd.go
@@ -1,0 +1,418 @@
+package etcd
+
+import (
+	"github.com/perses/community-dashboards/pkg/dashboards"
+	"github.com/perses/community-dashboards/pkg/promql"
+	"github.com/perses/perses/go-sdk/panel"
+	panelgroup "github.com/perses/perses/go-sdk/panel-group"
+	"github.com/perses/plugins/prometheus/sdk/go/query"
+
+	commonSdk "github.com/perses/perses/go-sdk/common"
+	statPanel "github.com/perses/plugins/statchart/sdk/go"
+	timeSeriesPanel "github.com/perses/plugins/timeserieschart/sdk/go"
+)
+
+func EtcdUpStatus(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Up",
+		panel.Description("Shows the status of etcd."),
+		statPanel.Chart(
+			statPanel.Format(commonSdk.Format{
+				Unit:          string(commonSdk.DecimalUnit),
+				DecimalPlaces: 0,
+			}),
+			statPanel.ValueFontSize(50),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(etcd_server_has_leader{job=~\".*etcd.*\", cluster=\"$cluster\"})",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{cluster}} {{namespace}}"),
+			),
+		),
+	)
+}
+
+func RPCRate(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("RPC Rate",
+		panel.Description("Shows the rate of gRPC requests."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.OpsPerSecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Stack:        timeSeriesPanel.AllStack,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(grpc_server_started_total{job=~\".*etcd.*\", cluster=\"$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("RPC Rate"),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(grpc_server_handled_total{job=~\".*etcd.*\", cluster=\"$cluster\",grpc_type=\"unary\",grpc_code=~\"Unknown|FailedPrecondition|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded\"}[$__rate_interval]))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("RPC failed Rate"),
+			),
+		),
+	)
+}
+
+func ActiveStreams(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Active Streams",
+		panel.Description("Shows the number of active streams."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.DecimalUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Stack:        timeSeriesPanel.AllStack,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(grpc_server_started_total{job=~\".*etcd.*\",cluster=\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{cluster=\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("Watch Streams"),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(grpc_server_started_total{job=~\".*etcd.*\",cluster=\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{cluster=\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("Lease Streams"),
+			),
+		),
+	)
+}
+
+func DBSize(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("DB Size",
+		panel.Description("Shows the size of the etcd database."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.BytesUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"etcd_mvcc_db_total_size_in_bytes{job=~\".*etcd.*\", cluster=\"$cluster\"}",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} DB Size"),
+			),
+		),
+	)
+}
+
+func DiskSyncDuration(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Disk Sync Duration",
+		panel.Description("Shows the duration of the etcd disk sync for WAL and DB."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.SecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=~\".*etcd.*\", cluster=\"$cluster\"}[$__rate_interval])) by (instance, le))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} WAL fsync"),
+			),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{job=~\".*etcd.*\", cluster=\"$cluster\"}[$__rate_interval])) by (instance, le))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} DB fsync"),
+			),
+		),
+	)
+}
+
+func ClientTrafficIn(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Client Traffic In",
+		panel.Description("Shows the client traffic into etcd."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.BytesPerSecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"rate(etcd_network_client_grpc_received_bytes_total{job=~\".*etcd.*\", cluster=\"$cluster\"}[$__rate_interval])",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} client traffic in"),
+			),
+		),
+	)
+}
+
+func ClientTrafficOut(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Client Traffic Out",
+		panel.Description("Shows the client traffic out of etcd."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.BytesPerSecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"rate(etcd_network_client_grpc_sent_bytes_total{job=~\".*etcd.*\", cluster=\"$cluster\"}[$__rate_interval])",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} client traffic out"),
+			),
+		),
+	)
+}
+
+func PeerTrafficIn(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Peer Traffic In",
+		panel.Description("Shows the peer traffic into etcd."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.BytesPerSecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(etcd_network_peer_received_bytes_total{job=~\".*etcd.*\", cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} peer traffic in"),
+			),
+		),
+	)
+}
+
+func PeerTrafficOut(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Peer Traffic Out",
+		panel.Description("Shows the peer traffic out of etcd."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.BytesPerSecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"sum(rate(etcd_network_peer_sent_bytes_total{job=~\".*etcd.*\", cluster=\"$cluster\"}[$__rate_interval])) by (instance)",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} peer traffic out"),
+			),
+		),
+	)
+}
+
+func RaftProposals(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Raft Proposals / Leader Elections in a day",
+		panel.Description("Shows the number of times etcd has leader elections in a day."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.DecimalUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"changes(etcd_server_leader_changes_seen_total{job=~\".*etcd.*\", cluster=\"$cluster\"}[1d])",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} total leader elections per day"),
+			),
+		),
+	)
+}
+
+func PeerRoundtripTime(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgroup.Option {
+	return panelgroup.AddPanel("Peer Roundtrip Time",
+		panel.Description("Shows the roundtrip time of the peer traffic."),
+		timeSeriesPanel.Chart(
+			timeSeriesPanel.WithYAxis(timeSeriesPanel.YAxis{
+				Format: &commonSdk.Format{
+					Unit: string(commonSdk.SecondsUnit),
+				},
+			}),
+			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
+				Position: timeSeriesPanel.BottomPosition,
+				Mode:     timeSeriesPanel.TableMode,
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
+		),
+		panel.AddQuery(
+			query.PromQL(
+				promql.SetLabelMatchers(
+					"histogram_quantile(0.99, sum by (instance, le) (rate(etcd_network_peer_round_trip_time_seconds_bucket{job=~\".*etcd.*\", cluster=\"$cluster\"}[$__rate_interval])))",
+					labelMatchers,
+				),
+				dashboards.AddQueryDataSource(datasourceName),
+				query.SeriesNameFormat("{{instance}} peer roundtrip time"),
+			),
+		),
+	)
+}


### PR DESCRIPTION
This commit ports over the etcd mixin from https://github.com/etcd-io/etcd/blob/main/contrib/mixin/mixin.libsonnet

In general this dashboard is mostly used with kubernetes, however as upstream is a separate mixin, let's keep it separate here.

There are some unrelated changes in the PR, but once we merge #81, those will go in, and I'll rebase.

![Screenshot 2025-05-14 at 09 26 51](https://github.com/user-attachments/assets/a63dde02-5dee-464f-8d67-a5470fa3fbb7)
![Screenshot 2025-05-14 at 09 26 40](https://github.com/user-attachments/assets/fad198ce-57f9-40d0-83db-94ac5d1c8d21)
