### PR TITLE
Fix: panel sizing - Blackbox and Alertmanager

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Welcome to the **Perses Community Dashboards** repository! This project is desig
 - Ruler Overview
 
 ### Kubernetes-mixin Dashboards
+- API Server
 - Compute Resources / Multi-Cluster
 - Compute Resources / Cluster
 - Compute Resources / Node

--- a/examples/dashboards/json/operator/alertmanager/alertmanager-overview.json
+++ b/examples/dashboards/json/operator/alertmanager/alertmanager-overview.json
@@ -85,6 +85,14 @@
                 "values": [
                   "last"
                 ]
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 1,
+                "palette": {
+                  "mode": "auto"
+                }
               }
             }
           },
@@ -124,6 +132,15 @@
                 "values": [
                   "last"
                 ]
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 1,
+                "palette": {
+                  "mode": "auto"
+                },
+                "stack": "all"
               }
             }
           },
@@ -179,6 +196,15 @@
                 "values": [
                   "last"
                 ]
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 1,
+                "palette": {
+                  "mode": "auto"
+                },
+                "stack": "all"
               }
             }
           },
@@ -238,6 +264,14 @@
               "yAxis": {
                 "format": {
                   "unit": "seconds"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
                 }
               }
             }
@@ -307,7 +341,7 @@
               "x": 0,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/0_0"
               }
@@ -316,7 +350,7 @@
               "x": 12,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/0_1"
               }
@@ -335,7 +369,7 @@
               "x": 0,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/1_0"
               }
@@ -344,7 +378,7 @@
               "x": 12,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/1_1"
               }

--- a/examples/dashboards/json/operator/blackbox-exporter/blackbox-overview.json
+++ b/examples/dashboards/json/operator/blackbox-exporter/blackbox-overview.json
@@ -99,7 +99,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -142,7 +143,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -194,7 +196,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -246,7 +249,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -288,7 +292,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -340,7 +345,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -393,7 +399,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -429,13 +436,19 @@
               "legend": {
                 "position": "bottom",
                 "mode": "table",
-                "values": [
-                  "last"
-                ]
+                "size": "small"
               },
               "yAxis": {
                 "format": {
                   "unit": "seconds"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
                 }
               }
             }
@@ -489,13 +502,19 @@
               "legend": {
                 "position": "bottom",
                 "mode": "table",
-                "values": [
-                  "last"
-                ]
+                "size": "small"
               },
               "yAxis": {
                 "format": {
                   "unit": "seconds"
+                }
+              },
+              "visual": {
+                "display": "line",
+                "lineWidth": 0.25,
+                "areaOpacity": 0.5,
+                "palette": {
+                  "mode": "auto"
                 }
               }
             }
@@ -570,7 +589,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -613,7 +633,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -656,7 +677,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -710,7 +732,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -752,7 +775,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -795,7 +819,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -837,7 +862,8 @@
               },
               "sparkline": {
                 "width": 1
-              }
+              },
+              "valueFontSize": 50
             }
           },
           "queries": [
@@ -872,7 +898,7 @@
               "x": 0,
               "y": 0,
               "width": 24,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/0_0"
               }
@@ -891,7 +917,7 @@
               "x": 0,
               "y": 0,
               "width": 6,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/1_0"
               }
@@ -900,7 +926,7 @@
               "x": 6,
               "y": 0,
               "width": 6,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/1_1"
               }
@@ -909,7 +935,7 @@
               "x": 12,
               "y": 0,
               "width": 6,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/1_2"
               }
@@ -918,7 +944,7 @@
               "x": 18,
               "y": 0,
               "width": 6,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/1_3"
               }
@@ -937,7 +963,7 @@
               "x": 0,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/2_0"
               }
@@ -946,7 +972,7 @@
               "x": 12,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/2_1"
               }
@@ -965,7 +991,7 @@
               "x": 0,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 10,
               "content": {
                 "$ref": "#/spec/panels/3_0"
               }
@@ -974,7 +1000,7 @@
               "x": 12,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 10,
               "content": {
                 "$ref": "#/spec/panels/3_1"
               }
@@ -993,7 +1019,7 @@
               "x": 0,
               "y": 0,
               "width": 4,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/4_0"
               }
@@ -1002,7 +1028,7 @@
               "x": 4,
               "y": 0,
               "width": 4,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/4_1"
               }
@@ -1011,7 +1037,7 @@
               "x": 8,
               "y": 0,
               "width": 4,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/4_2"
               }
@@ -1020,7 +1046,7 @@
               "x": 12,
               "y": 0,
               "width": 4,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/4_3"
               }
@@ -1029,7 +1055,7 @@
               "x": 16,
               "y": 0,
               "width": 4,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/4_4"
               }
@@ -1048,7 +1074,7 @@
               "x": 0,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/5_0"
               }
@@ -1057,7 +1083,7 @@
               "x": 12,
               "y": 0,
               "width": 12,
-              "height": 6,
+              "height": 8,
               "content": {
                 "$ref": "#/spec/panels/5_1"
               }

--- a/examples/dashboards/operator/alertmanager/alertmanager-overview.yaml
+++ b/examples/dashboards/operator/alertmanager/alertmanager-overview.yaml
@@ -21,13 +21,13 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/0_0'
-        height: 6
+        height: 8
         width: 12
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/0_1'
-        height: 6
+        height: 8
         width: 12
         x: 12
         "y": 0
@@ -38,13 +38,13 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/1_0'
-        height: 6
+        height: 8
         width: 12
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/1_1'
-        height: 6
+        height: 8
         width: 12
         x: 12
         "y": 0
@@ -63,6 +63,12 @@ spec:
               position: bottom
               values:
               - last
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -88,6 +94,13 @@ spec:
               position: bottom
               values:
               - last
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+              stack: all
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -123,6 +136,13 @@ spec:
               position: bottom
               values:
               - last
+            visual:
+              areaOpacity: 1
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
+              stack: all
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -164,6 +184,12 @@ spec:
               position: bottom
               values:
               - last
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: seconds

--- a/examples/dashboards/operator/blackbox-exporter/blackbox-overview.yaml
+++ b/examples/dashboards/operator/blackbox-exporter/blackbox-overview.yaml
@@ -21,7 +21,7 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/0_0'
-        height: 6
+        height: 8
         width: 24
         x: 0
         "y": 0
@@ -32,25 +32,25 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/1_0'
-        height: 6
+        height: 8
         width: 6
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/1_1'
-        height: 6
+        height: 8
         width: 6
         x: 6
         "y": 0
       - content:
           $ref: '#/spec/panels/1_2'
-        height: 6
+        height: 8
         width: 6
         x: 12
         "y": 0
       - content:
           $ref: '#/spec/panels/1_3'
-        height: 6
+        height: 8
         width: 6
         x: 18
         "y": 0
@@ -61,13 +61,13 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/2_0'
-        height: 6
+        height: 8
         width: 12
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/2_1'
-        height: 6
+        height: 8
         width: 12
         x: 12
         "y": 0
@@ -78,13 +78,13 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/3_0'
-        height: 6
+        height: 10
         width: 12
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/3_1'
-        height: 6
+        height: 10
         width: 12
         x: 12
         "y": 0
@@ -95,31 +95,31 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/4_0'
-        height: 6
+        height: 8
         width: 4
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/4_1'
-        height: 6
+        height: 8
         width: 4
         x: 4
         "y": 0
       - content:
           $ref: '#/spec/panels/4_2'
-        height: 6
+        height: 8
         width: 4
         x: 8
         "y": 0
       - content:
           $ref: '#/spec/panels/4_3'
-        height: 6
+        height: 8
         width: 4
         x: 12
         "y": 0
       - content:
           $ref: '#/spec/panels/4_4'
-        height: 6
+        height: 8
         width: 4
         x: 16
         "y": 0
@@ -130,13 +130,13 @@ spec:
       items:
       - content:
           $ref: '#/spec/panels/5_0'
-        height: 6
+        height: 8
         width: 12
         x: 0
         "y": 0
       - content:
           $ref: '#/spec/panels/5_1'
-        height: 6
+        height: 8
         width: 12
         x: 12
         "y": 0
@@ -163,6 +163,7 @@ spec:
                 value: 0
               - color: green
                 value: 1
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -191,6 +192,7 @@ spec:
             thresholds:
               defaultColor: green
               mode: absolute
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -223,6 +225,7 @@ spec:
                 value: 0.99
               - color: green
                 value: 0.999
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -255,6 +258,7 @@ spec:
                 value: 0.99
               - color: green
                 value: 0.999
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -282,6 +286,7 @@ spec:
             thresholds:
               defaultColor: green
               mode: absolute
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -314,6 +319,7 @@ spec:
                 value: 0.99
               - color: green
                 value: 0.999
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -347,6 +353,7 @@ spec:
                 value: 0.99
               - color: green
                 value: 0.999
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -370,8 +377,13 @@ spec:
             legend:
               mode: table
               position: bottom
-              values:
-              - last
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: seconds
@@ -411,8 +423,13 @@ spec:
             legend:
               mode: table
               position: bottom
-              values:
-              - last
+              size: small
+            visual:
+              areaOpacity: 0.5
+              display: line
+              lineWidth: 0.25
+              palette:
+                mode: auto
             yAxis:
               format:
                 unit: seconds
@@ -461,6 +478,7 @@ spec:
                 value: 400
               - color: blue
                 value: 300
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -489,6 +507,7 @@ spec:
             thresholds:
               defaultColor: green
               mode: absolute
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -517,6 +536,7 @@ spec:
             thresholds:
               defaultColor: green
               mode: absolute
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -552,6 +572,7 @@ spec:
               - color: blue
                 name: "Yes"
                 value: 1
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -579,6 +600,7 @@ spec:
             thresholds:
               defaultColor: blue
               mode: absolute
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -607,6 +629,7 @@ spec:
             thresholds:
               defaultColor: green
               mode: absolute
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:
@@ -634,6 +657,7 @@ spec:
             thresholds:
               defaultColor: green
               mode: absolute
+            valueFontSize: 50
         queries:
         - kind: TimeSeriesQuery
           spec:

--- a/examples/dashboards/perses/alertmanager/alertmanager-overview.yaml
+++ b/examples/dashboards/perses/alertmanager/alertmanager-overview.yaml
@@ -58,6 +58,12 @@ spec:
                             mode: table
                             values:
                                 - last
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -83,6 +89,13 @@ spec:
                             mode: table
                             values:
                                 - last
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
+                            stack: all
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -118,6 +131,13 @@ spec:
                             mode: table
                             values:
                                 - last
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 1
+                            palette:
+                                mode: auto
+                            stack: all
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -162,6 +182,12 @@ spec:
                         yAxis:
                             format:
                                 unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -229,13 +255,13 @@ spec:
                 - x: 0
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/0_0'
                 - x: 12
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/0_1'
         - kind: Grid
@@ -246,13 +272,13 @@ spec:
                 - x: 0
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/1_0'
                 - x: 12
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/1_1'
     duration: 1h

--- a/examples/dashboards/perses/blackbox-exporter/blackbox-overview.yaml
+++ b/examples/dashboards/perses/blackbox-exporter/blackbox-overview.yaml
@@ -66,6 +66,7 @@ spec:
                                   color: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -94,6 +95,7 @@ spec:
                             defaultColor: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -126,6 +128,7 @@ spec:
                                   color: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -158,6 +161,7 @@ spec:
                                   color: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -185,6 +189,7 @@ spec:
                             defaultColor: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -217,6 +222,7 @@ spec:
                                   color: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -250,6 +256,7 @@ spec:
                                   color: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -273,11 +280,16 @@ spec:
                         legend:
                             position: bottom
                             mode: table
-                            values:
-                                - last
+                            size: small
                         yAxis:
                             format:
                                 unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -314,11 +326,16 @@ spec:
                         legend:
                             position: bottom
                             mode: table
-                            values:
-                                - last
+                            size: small
                         yAxis:
                             format:
                                 unit: seconds
+                        visual:
+                            display: line
+                            lineWidth: 0.25
+                            areaOpacity: 0.5
+                            palette:
+                                mode: auto
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -364,6 +381,7 @@ spec:
                                   color: blue
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -392,6 +410,7 @@ spec:
                             defaultColor: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -420,6 +439,7 @@ spec:
                             defaultColor: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -454,6 +474,7 @@ spec:
                                   name: "Yes"
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -481,6 +502,7 @@ spec:
                             defaultColor: blue
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -509,6 +531,7 @@ spec:
                             defaultColor: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -536,6 +559,7 @@ spec:
                             defaultColor: green
                         sparkline:
                             width: 1
+                        valueFontSize: 50
                 queries:
                     - kind: TimeSeriesQuery
                       spec:
@@ -555,7 +579,7 @@ spec:
                 - x: 0
                   "y": 0
                   width: 24
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/0_0'
         - kind: Grid
@@ -566,25 +590,25 @@ spec:
                 - x: 0
                   "y": 0
                   width: 6
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/1_0'
                 - x: 6
                   "y": 0
                   width: 6
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/1_1'
                 - x: 12
                   "y": 0
                   width: 6
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/1_2'
                 - x: 18
                   "y": 0
                   width: 6
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/1_3'
         - kind: Grid
@@ -595,13 +619,13 @@ spec:
                 - x: 0
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/2_0'
                 - x: 12
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/2_1'
         - kind: Grid
@@ -612,13 +636,13 @@ spec:
                 - x: 0
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 10
                   content:
                     $ref: '#/spec/panels/3_0'
                 - x: 12
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 10
                   content:
                     $ref: '#/spec/panels/3_1'
         - kind: Grid
@@ -629,31 +653,31 @@ spec:
                 - x: 0
                   "y": 0
                   width: 4
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/4_0'
                 - x: 4
                   "y": 0
                   width: 4
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/4_1'
                 - x: 8
                   "y": 0
                   width: 4
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/4_2'
                 - x: 12
                   "y": 0
                   width: 4
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/4_3'
                 - x: 16
                   "y": 0
                   width: 4
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/4_4'
         - kind: Grid
@@ -664,13 +688,13 @@ spec:
                 - x: 0
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/5_0'
                 - x: 12
                   "y": 0
                   width: 12
-                  height: 6
+                  height: 8
                   content:
                     $ref: '#/spec/panels/5_1'
     duration: 1h

--- a/pkg/dashboards/alertmanager/alertmanager_overview.go
+++ b/pkg/dashboards/alertmanager/alertmanager_overview.go
@@ -13,6 +13,7 @@ import (
 func withAlertsGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Alerts",
 		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
 		panels.Alerts(datasource, labelMatcher),
 		panels.AlertsReceiveRate(datasource, labelMatcher),
 	)
@@ -21,6 +22,7 @@ func withAlertsGroup(datasource string, labelMatcher promql.LabelMatcher) dashbo
 func withNotificationsGroup(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Notifications",
 		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
 		panels.NotificationsSendRate(datasource, labelMatcher),
 		panels.NotificationDuration(datasource, labelMatcher),
 	)

--- a/pkg/dashboards/blackbox/blackbox.go
+++ b/pkg/dashboards/blackbox/blackbox.go
@@ -14,6 +14,7 @@ import (
 func withBlackboxSummary(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Summary",
 		panelgroup.PanelsPerLine(1),
+		panelgroup.PanelHeight(8),
 		panels.ProbeStatusMap(datasource, labelMatcher),
 	)
 }
@@ -21,6 +22,7 @@ func withBlackboxSummary(datasource string, labelMatcher promql.LabelMatcher) da
 func withBlackboxProbesStats(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Probes Stats",
 		panelgroup.PanelsPerLine(4),
+		panelgroup.PanelHeight(8),
 		panels.ProbeSuccessCount(datasource, labelMatcher),
 		panels.ProbeSuccessPercent(datasource, labelMatcher),
 		panels.ProbeHTTPSSL(datasource, labelMatcher),
@@ -31,6 +33,7 @@ func withBlackboxProbesStats(datasource string, labelMatcher promql.LabelMatcher
 func withBlackboxProbesUptime(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Probes Uptimes Stats",
 		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
 		panels.ProbeUptimeSuccess(datasource, labelMatcher),
 		panels.ProbeUptimeMonthly(datasource, labelMatcher),
 	)
@@ -39,6 +42,7 @@ func withBlackboxProbesUptime(datasource string, labelMatcher promql.LabelMatche
 func withBlackboxProbes(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Probes",
 		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(10),
 		panels.ProbeDurationSeconds(datasource, labelMatcher),
 		panels.ProbePhases(datasource, labelMatcher),
 	)
@@ -47,6 +51,7 @@ func withBlackboxProbes(datasource string, labelMatcher promql.LabelMatcher) das
 func withBlackboxProbesAdditionalStats(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Probes Additional Stats",
 		panelgroup.PanelsPerLine(5),
+		panelgroup.PanelHeight(8),
 		panels.ProbeStatusCode(datasource, labelMatcher),
 		panels.ProbeTLSVersion(datasource, labelMatcher),
 		panels.ProbeSSLExpiry(datasource, labelMatcher),
@@ -58,6 +63,7 @@ func withBlackboxProbesAdditionalStats(datasource string, labelMatcher promql.La
 func withBlackboxProbesAvgTime(datasource string, labelMatcher promql.LabelMatcher) dashboard.Option {
 	return dashboard.AddPanelGroup("Probes Avg Duration Stats",
 		panelgroup.PanelsPerLine(2),
+		panelgroup.PanelHeight(8),
 		panels.ProbeAverageDurationInstance(datasource, labelMatcher),
 		panels.ProbeAverageDNSLookupPerInstance(datasource, labelMatcher),
 	)

--- a/pkg/panels/alertmanager/alertmanager.go
+++ b/pkg/panels/alertmanager/alertmanager.go
@@ -32,6 +32,13 @@ func Alerts(datasourceName string, labelMatchers ...promql.LabelMatcher) panelgr
 				Mode:     timeSeriesPanel.TableMode,
 				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
 			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
+			}),
 		),
 		panel.AddQuery(
 			query.PromQL(
@@ -69,6 +76,14 @@ func AlertsReceiveRate(datasourceName string, labelMatchers ...promql.LabelMatch
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
 				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Stack:        timeSeriesPanel.AllStack,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(
@@ -123,6 +138,14 @@ func NotificationsSendRate(datasourceName string, labelMatchers ...promql.LabelM
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
 				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  1,
+				Stack:        timeSeriesPanel.AllStack,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(
@@ -181,6 +204,13 @@ func NotificationDuration(datasourceName string, labelMatchers ...promql.LabelMa
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
 				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(

--- a/pkg/panels/blackbox/blackbox.go
+++ b/pkg/panels/blackbox/blackbox.go
@@ -38,6 +38,7 @@ func ProbeStatusMap(datasourceName string, labelMatchers ...promql.LabelMatcher)
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "green",
@@ -92,6 +93,7 @@ func ProbeSuccessCount(datasourceName string, labelMatchers ...promql.LabelMatch
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "green",
@@ -134,6 +136,7 @@ func ProbeSuccessPercent(datasourceName string, labelMatchers ...promql.LabelMat
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "red",
@@ -187,6 +190,7 @@ func ProbeHTTPSSL(datasourceName string, labelMatchers ...promql.LabelMatcher) p
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "red",
@@ -239,6 +243,7 @@ func ProbeAverageDuration(datasourceName string, labelMatchers ...promql.LabelMa
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "green",
@@ -282,6 +287,7 @@ func ProbeUptimeSuccess(datasourceName string, labelMatchers ...promql.LabelMatc
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "red",
@@ -335,6 +341,7 @@ func ProbeUptimeMonthly(datasourceName string, labelMatchers ...promql.LabelMatc
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "red",
@@ -391,7 +398,14 @@ func ProbeDurationSeconds(datasourceName string, labelMatchers ...promql.LabelMa
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
-				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(
@@ -444,7 +458,14 @@ func ProbePhases(datasourceName string, labelMatchers ...promql.LabelMatcher) pa
 			timeSeriesPanel.WithLegend(timeSeriesPanel.Legend{
 				Position: timeSeriesPanel.BottomPosition,
 				Mode:     timeSeriesPanel.TableMode,
-				Values:   []commonSdk.Calculation{commonSdk.LastCalculation},
+				Size:     timeSeriesPanel.SmallSize,
+			}),
+			timeSeriesPanel.WithVisual(timeSeriesPanel.Visual{
+				Display:      timeSeriesPanel.LineDisplay,
+				ConnectNulls: false,
+				LineWidth:    0.25,
+				AreaOpacity:  0.5,
+				Palette:      timeSeriesPanel.Palette{Mode: timeSeriesPanel.AutoMode},
 			}),
 		),
 		panel.AddQuery(
@@ -493,6 +514,7 @@ func ProbeStatusCode(datasourceName string, labelMatchers ...promql.LabelMatcher
 				Unit:          string(commonSdk.DecimalUnit),
 				DecimalPlaces: 0,
 			}),
+			stat.ValueFontSize(50),
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
@@ -553,6 +575,7 @@ func ProbeTLSVersion(datasourceName string, labelMatchers ...promql.LabelMatcher
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "green",
@@ -596,6 +619,7 @@ func ProbeSSLExpiry(datasourceName string, labelMatchers ...promql.LabelMatcher)
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "green",
@@ -639,6 +663,7 @@ func ProbeRedirects(datasourceName string, labelMatchers ...promql.LabelMatcher)
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "blue",
@@ -693,6 +718,7 @@ func ProbeHTTPVersion(datasourceName string, labelMatchers ...promql.LabelMatche
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "blue",
@@ -736,6 +762,7 @@ func ProbeAverageDurationInstance(datasourceName string, labelMatchers ...promql
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "green",
@@ -778,6 +805,7 @@ func ProbeAverageDNSLookupPerInstance(datasourceName string, labelMatchers ...pr
 			stat.WithSparkline(stat.Sparkline{
 				Width: 1,
 			}),
+			stat.ValueFontSize(50),
 			stat.Thresholds(commonSdk.Thresholds{
 				Mode:         commonSdk.AbsoluteMode,
 				DefaultColor: "green",


### PR DESCRIPTION
Improve panel sizing for Blackbox and Alertmanager dashboards, also missing commit from previous pr https://github.com/perses/community-dashboards/pull/63

Some screenshots of the changes

<img width="1892" alt="Screenshot 2025-05-14 at 19 42 58" src="https://github.com/user-attachments/assets/d857b824-e18e-4e21-a290-f4645246b3b8" />
<img width="1904" alt="Screenshot 2025-05-14 at 19 50 57" src="https://github.com/user-attachments/assets/ffec667e-38b3-488f-9370-8288d2a274fa" />
