### PR TITLE
[CI] adding dac lint

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-golang:
     runs-on: ubuntu-latest
-    name: Golang and UI Linting
+    name: Golang Linting
     steps:
       - uses: actions/checkout@v4
       - name: Import environment variables from file
@@ -26,7 +26,29 @@ jobs:
         uses: golangci/golangci-lint-action@v8.0.0
         with:
           version: v2.1.1
-          args: --timeout 10m0s 
+          args: --timeout 10m0s
+
+  check-dashboards:
+    runs-on: ubuntu-latest
+    name: Dashboards Linting
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Import environment variables from file
+        run: cat ".github/env" >> $GITHUB_ENV
+
+      - name: Build dashboards
+        run: make build-dashboards-local
+      
+      - name: Install percli
+        uses: perses/cli-actions/actions/install_percli@v0.1.0
+        with:
+          cli-version: "latest"
+
+      - name: Validate Resources with Perses CLI
+        uses: perses/cli-actions/actions/validate_resources@main
+        with:
+          directory: './built/dashboards/perses'
 
   format:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve the linting process by separating concerns and adding a new job for dashboard validation. The most important changes include renaming an existing job for clarity and introducing a new job to validate dashboards using the Perses CLI.

### Workflow Updates:

* [`.github/workflows/checks.yaml`](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5L10-R10): Renamed the `check-golang` job from "Golang and UI Linting" to "Golang Linting" to better reflect its scope.
* [`.github/workflows/checks.yaml`](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5R31-R46): Added a new `check-dashboards` job to validate dashboards. This includes steps to build dashboards locally and validate them using the Perses CLI.