### PR TITLE
[CHORE] adding code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nicolastakashi @saswatamcode @ibakshay


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to assign ownership of all files to specific team members.

Ownership update:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1): Added `@nicolastakashi`, `@saswatamcode`, and `@ibakshay` as code owners for all files in the repository.