### PR TITLE
Update matcher for apiserver resources

### DIFF
--- a/pkg/dashboards/kubernetes/apiserver/apiserver.go
+++ b/pkg/dashboards/kubernetes/apiserver/apiserver.go
@@ -66,11 +66,16 @@ func withWorkQueueGroup(datasource string, labelMatcher promql.LabelMatcher) das
 }
 
 func withAPIServerResources(datasource string, clusterLabelMatcher *labels.Matcher) dashboard.Option {
-	// Use GetLabelMatchers to parse the matcher into prometheus objects
-	labelMatchersToUse, err := parser.ParseMetricSelector("{" + panels.GetAPIServerMatcher() + "}")
+	labelMatchersToUse := []*labels.Matcher{
+		promql.ClusterVarV2,
+		promql.InstanceVarV2,
+	}
+
+	apiServerLabelMatchers, err := parser.ParseMetricSelector("{" + panels.GetAPIServerMatcher() + "}")
 	if err != nil {
 		log.Fatalf("error parsing API server matcher: '%s', err=%v", panels.GetAPIServerMatcher(), err.Error())
 	}
+	labelMatchersToUse = append(labelMatchersToUse, apiServerLabelMatchers...)
 
 	labelMatchersToUse = append(labelMatchersToUse, clusterLabelMatcher)
 


### PR DESCRIPTION
The apiserver dashboard had still some hard-coded label: using the globals instead.