### PR TITLE
fix: mixins demo

### DIFF
--- a/examples/docker-compose.yaml
+++ b/examples/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   perses:
-    image: persesdev/perses:v0.51-distroless-debug
+    image: persesdev/perses:v0.53-distroless-debug
     container_name: perses
     command: "--config=/etc/perses/config/config.yaml"
     ports:

--- a/examples/perses/datasource.yaml
+++ b/examples/perses/datasource.yaml
@@ -1,10 +1,10 @@
 ---
 kind: GlobalDatasource
 metadata:
-  name: PrometheusDemo
+  name: prometheus-datasource
 spec:
   default: true
   plugin:
     kind: PrometheusDatasource
     spec:
-      directUrl: https://demo.promlabs.com
+      directUrl: https://prometheus.demo.prometheus.io

--- a/examples/perses/project.yaml
+++ b/examples/perses/project.yaml
@@ -1,6 +1,6 @@
 kind: Project
 metadata:
-  name: default
+  name: perses-dev
 spec:
   display:
-    name: "default"
+    name: "perses-dev"


### PR DESCRIPTION
Fixing the local demo, so we can use the docker compose to actually apply the dashboards to test for example, or new users. Also bump the image. 
https://prometheus.demo.prometheus.io is up again and does have a couple of exporter metrics so it does allow users to test easily, for example 

<img width="864" height="600" alt="Screenshot 2025-10-16 at 19 33 09" src="https://github.com/user-attachments/assets/702c6afb-9857-4a65-b08c-f16cfb41395c" />
