### PR TITLE
Remove requirement for output flags in NewExec

### DIFF
--- a/pkg/dashboards/exec.go
+++ b/pkg/dashboards/exec.go
@@ -94,10 +94,6 @@ func NewExec() Exec {
 	output := flag.Lookup("output").Value.String()
 	outputDir := flag.Lookup("output-dir").Value.String()
 
-	if output == "" || outputDir == "" {
-		panic("output and output-dir flags are required for generating dashboards")
-	}
-
 	return Exec{
 		outputFormat: output,
 		outputDir:    outputDir,


### PR DESCRIPTION
Removed panic for missing output and output-dir flags. We already check it and panic in executeDashboardBuilder