### PR TITLE
Add alerts for Thanos Operator

### DIFF
--- a/examples/rules/operator/thanos-operator/thanos-operator-alerts.yaml
+++ b/examples/rules/operator/thanos-operator/thanos-operator-alerts.yaml
@@ -1,0 +1,600 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app.kubernetes.io/component: thanos-operator
+    app.kubernetes.io/name: thanos-operator-rules
+    app.kubernetes.io/part-of: thanos-operator
+    app.kubernetes.io/version: main
+  name: thanos-operator-alerts
+  namespace: monitoring
+spec:
+  groups:
+  - interval: 30s
+    name: thanos-operator.general
+    rules:
+    - alert: ThanosOperatorDown
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: The Thanos Operator has been down for more than 5 minutes. No
+          reconciliation is happening.
+        message: Thanos resources are not being reconciled. Configuration changes
+          will not be applied.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosoperatordown
+        summary: Thanos Operator is down
+      expr: up{job="thanos-operator-controller-manager-metrics-service"} == 0
+      for: 5m
+      labels:
+        component: thanos-operator
+        service: thanos-operator
+        severity: critical
+    - alert: ThanosOperatorHighReconcileErrorRate
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: Controller {{ $labels.controller }} has an error rate of {{ $value
+          | humanizePercentage }} over the last 10 minutes.
+        message: Resources managed by this controller may not be correctly configured
+          or updated.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosoperatorhighreconcileerrorrate
+        summary: High reconciliation error rate for {{ $labels.controller }}
+      expr: |2-
+            sum by (controller) (
+              rate(
+                controller_runtime_reconcile_errors_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+              )
+            )
+          /
+            sum by (controller) (
+              rate(
+                controller_runtime_reconcile_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+              )
+            )
+        >
+          0.1
+      for: 10m
+      labels:
+        component: thanos-operator
+        controller: '{{ $labels.controller }}'
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosOperatorReconcileStuck
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: Workqueue for {{ $labels.name }} has items but no reconciliations
+          are happening.
+        message: Changes to Thanos resources are not being processed.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosoperatorreconcilestuck
+        summary: Controller {{ $labels.name }} appears stuck
+      expr: |2-
+            rate(
+              controller_runtime_reconcile_total{job="thanos-operator-controller-manager-metrics-service"}[10m]
+            )
+          ==
+            0
+        and on (controller, job)
+          workqueue_depth{job="thanos-operator-controller-manager-metrics-service"} > 0
+      for: 15m
+      labels:
+        component: thanos-operator
+        controller: '{{ $labels.controller }}'
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosOperatorWorkQueueGrowth
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: Workqueue depth for {{ $labels.name }} is {{ $value }}, indicating
+          the controller cannot keep up with events.
+        message: Reconciliation is falling behind. Configuration updates may be delayed.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosoperatorworkqueuegrowth
+        summary: Controller workqueue {{ $labels.name }} is growing
+      expr: workqueue_depth{job="thanos-operator-controller-manager-metrics-service"}
+        > 100
+      for: 15m
+      labels:
+        component: thanos-operator
+        controller: '{{ $labels.controller }}'
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosOperatorSlowReconciliation
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: P99 reconciliation time for {{ $labels.controller }} is {{ $value
+          | humanizeDuration }}
+        message: Configuration changes are taking longer than expected to apply.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosoperatorslowreconciliation
+        summary: Slow reconciliation for {{ $labels.controller }}
+      expr: |2-
+          histogram_quantile(
+            0.99,
+            rate(
+              controller_runtime_reconcile_time_seconds_bucket{job="thanos-operator-controller-manager-metrics-service"}[10m]
+            )
+          )
+        >
+          60
+      for: 10m
+      labels:
+        component: thanos-operator
+        controller: '{{ $labels.controller }}'
+        service: thanos-operator
+        severity: warning
+  - interval: 30s
+    name: thanos-operator.query
+    rules:
+    - alert: ThanosQueryNoEndpointsConfigured
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosQuery resource {{ $labels.namespace }}/{{ $labels.resource
+          }} has no store endpoints configured.
+        message: Query component cannot retrieve data from any stores. Queries will
+          return no results.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosquerynoendpointsconfigured
+        summary: ThanosQuery {{ $labels.namespace }}/{{ $labels.resource }} has no
+          endpoints configured
+      expr: |2-
+          thanos_operator_query_endpoints_configured{job="thanos-operator-controller-manager-metrics-service"}
+        ==
+          0
+      for: 10m
+      labels:
+        component: thanos-query
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosQueryReconcileErrors
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosQuery controller has {{ $value | humanize }} errors/sec
+        message: ThanosQuery resources may not be properly configured or updated.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosqueryreconcileerrors
+        summary: ThanosQuery controller experiencing reconciliation errors
+      expr: |2-
+          rate(
+            controller_runtime_reconcile_errors_total{controller="thanosquery",job="thanos-operator-controller-manager-metrics-service"}[10m]
+          )
+        >
+          0
+      for: 15m
+      labels:
+        component: thanos-query
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosQueryServiceWatchReconcileStorm
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosQuery {{ $labels.namespace }}/{{ $labels.resource }} is
+          reconciling {{ $value | humanize }} times/sec due to service events.
+        message: Excessive reconciliations may indicate service churn or configuration
+          issues.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosqueryservicewatchreconcilestorm
+        summary: High service watch reconciliation rate for ThanosQuery {{ $labels.namespace
+          }}/{{ $labels.resource }}
+      expr: |2-
+          rate(
+            thanos_operator_query_service_event_reconciliations_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+          )
+        >
+          2
+      for: 10m
+      labels:
+        component: thanos-query
+        service: thanos-operator
+        severity: warning
+  - interval: 30s
+    name: thanos-operator.receive
+    rules:
+    - alert: ThanosReceiveNoHashringsConfigured
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosReceive resource {{ $labels.namespace }}/{{ $labels.resource
+          }} has no hashrings configured.
+        message: Receive component cannot accept remote write data without hashring
+          configuration.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosreceivenohashringsconfigured
+        summary: ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }} has
+          no hashrings configured
+      expr: |2-
+          thanos_operator_receive_hashrings_configured{job="thanos-operator-controller-manager-metrics-service"}
+        ==
+          0
+      for: 10m
+      labels:
+        component: thanos-receive
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosReceiveHashringNoEndpoints
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: Hashring {{ $labels.hashring }} for ThanosReceive {{ $labels.namespace
+          }}/{{ $labels.resource }} has no endpoints configured.
+        message: Data cannot be distributed to this hashring. Remote write data may
+          be lost or rejected.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosreceivehashringnoendpoints
+        summary: ThanosReceive hashring {{ $labels.hashring }} has no endpoints
+      expr: |2-
+          thanos_operator_receive_hashring_endpoints_configured{job="thanos-operator-controller-manager-metrics-service"}
+        ==
+          0
+      for: 10m
+      labels:
+        component: thanos-receive
+        service: thanos-operator
+        severity: critical
+    - alert: ThanosReceiveHashringConfigurationChange
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: The hashring configuration for ThanosReceive {{ $labels.namespace
+          }}/{{ $labels.resource }} has changed.
+        message: Data distribution pattern has changed. This may cause temporary inconsistencies.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosreceivehashringconfigurationchange
+        summary: ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }} hashring
+          configuration changed
+      expr: |2-
+          abs(
+            delta(
+              thanos_operator_receive_hashring_hash{job="thanos-operator-controller-manager-metrics-service"}[5m]
+            )
+          )
+        >
+          0
+      for: 0m
+      labels:
+        component: thanos-receive
+        service: thanos-operator
+        severity: info
+    - alert: ThanosReceiveReconcileErrors
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosReceive controller has {{ $value | humanize }} errors/sec
+        message: ThanosReceive resources may not be properly configured or updated.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosreceivereconcileerrors
+        summary: ThanosReceive controller experiencing reconciliation errors
+      expr: |2-
+          rate(
+            controller_runtime_reconcile_errors_total{controller="thanosreceive",job="thanos-operator-controller-manager-metrics-service"}[10m]
+          )
+        >
+          0
+      for: 15m
+      labels:
+        component: thanos-receive
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosReceiveEndpointReconcileStorm
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }}
+          is reconciling {{ $value | humanize }} times/sec due to endpoint events.
+        message: Excessive reconciliations may indicate endpoint churn or configuration
+          issues.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosreceiveendpointreconcilestorm
+        summary: High endpoint watch reconciliation rate for ThanosReceive {{ $labels.namespace
+          }}/{{ $labels.resource }}
+      expr: |2-
+          rate(
+            thanos_operator_receive_endpoint_event_reconciliations_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+          )
+        >
+          2
+      for: 10m
+      labels:
+        component: thanos-receive
+        service: thanos-operator
+        severity: warning
+  - interval: 30s
+    name: thanos-operator.ruler
+    rules:
+    - alert: ThanosRulerNoQueryEndpointsConfigured
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosRuler resource {{ $labels.namespace }}/{{ $labels.resource
+          }} has no query endpoints configured.
+        message: Ruler cannot query data for rule evaluation. Recording and alerting
+          rules will not work.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosrulernoqueryendpointsconfigured
+        summary: ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} has no
+          query endpoints configured
+      expr: |2-
+          thanos_operator_ruler_query_endpoints_configured{job="thanos-operator-controller-manager-metrics-service"}
+        ==
+          0
+      for: 10m
+      labels:
+        component: thanos-ruler
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosRulerNoRulesConfigured
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: No PrometheusRules found for ThanosRuler {{ $labels.namespace
+          }}/{{ $labels.resource }}.
+        message: No rules are being evaluated. This may be expected if no rules have
+          been defined yet.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosrulernorulesconfigured
+        summary: ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} has no
+          PrometheusRules
+      expr: thanos_operator_ruler_promrules_found{job="thanos-operator-controller-manager-metrics-service"}
+        == 0
+      for: 10m
+      labels:
+        component: thanos-ruler
+        service: thanos-operator
+        severity: info
+    - alert: ThanosRulerConfigMapCreationFailures
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosRuler controller is failing to create ConfigMaps for {{
+          $labels.namespace }}/{{ $labels.resource }}.
+        message: PrometheusRules cannot be loaded into the Ruler. Rules will not be
+          evaluated.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosrulerconfigmapcreationfailures
+        summary: ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} failing
+          to create ConfigMaps
+      expr: |2-
+          rate(
+            thanos_operator_ruler_cfgmaps_creation_failures_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+          )
+        >
+          0
+      for: 5m
+      labels:
+        component: thanos-ruler
+        service: thanos-operator
+        severity: critical
+    - alert: ThanosRulerHighConfigMapCreationRate
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} is
+          creating ConfigMaps at {{ $value | humanize }}/sec.
+        message: Excessive ConfigMap updates may indicate rule churn and cause unnecessary
+          Ruler reloads.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosrulerhighconfigmapcreationrate
+        summary: High ConfigMap creation rate for ThanosRuler {{ $labels.namespace
+          }}/{{ $labels.resource }}
+      expr: |2-
+          rate(
+            thanos_operator_ruler_cfgmaps_created_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+          )
+        >
+          1
+      for: 15m
+      labels:
+        component: thanos-ruler
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosRulerReconcileErrors
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosRuler controller has {{ $value | humanize }} errors/sec
+        message: ThanosRuler resources may not be properly configured or updated.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosrulerreconcileerrors
+        summary: ThanosRuler controller experiencing reconciliation errors
+      expr: |2-
+          rate(
+            controller_runtime_reconcile_errors_total{controller="thanosruler",job="thanos-operator-controller-manager-metrics-service"}[10m]
+          )
+        >
+          0
+      for: 15m
+      labels:
+        component: thanos-ruler
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosRulerWatchReconcileStorm
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} is
+          experiencing high reconciliation rate.
+        message: Excessive reconciliations may indicate resource churn or configuration
+          issues.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosrulerwatchreconcilestorm
+        summary: High watch reconciliation rate for ThanosRuler {{ $labels.namespace
+          }}/{{ $labels.resource }}
+      expr: |2-
+              rate(
+                thanos_operator_ruler_service_event_reconciliations_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+              )
+            >
+              2
+          or
+              rate(
+                thanos_operator_ruler_cfgmap_event_reconciliations_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+              )
+            >
+              2
+        or
+            rate(
+              thanos_operator_ruler_promrule_event_reconciliations_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+            )
+          >
+            2
+      for: 10m
+      labels:
+        component: thanos-ruler
+        service: thanos-operator
+        severity: warning
+  - interval: 30s
+    name: thanos-operator.store
+    rules:
+    - alert: ThanosStoreNoShardsConfigured
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosStore resource {{ $labels.namespace }}/{{ $labels.resource
+          }} has 0 shards configured.
+        message: This may be expected for single-instance stores. For sharded deployments,
+          data queries may fail.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosstenoreshardsconfigured
+        summary: ThanosStore {{ $labels.namespace }}/{{ $labels.resource }} has no
+          shards configured
+      expr: |2-
+          thanos_operator_store_shards_configured{job="thanos-operator-controller-manager-metrics-service"}
+        ==
+          0
+      for: 10m
+      labels:
+        component: thanos-store
+        service: thanos-operator
+        severity: info
+    - alert: ThanosStoreShardCreationFailures
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosStore controller is failing to create/update shards for
+          {{ $labels.namespace }}/{{ $labels.resource }}.
+        message: Store shards cannot be created. Historical data queries may be incomplete
+          or fail.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosstoreshardcreationfailures
+        summary: ThanosStore {{ $labels.namespace }}/{{ $labels.resource }} shard
+          creation/update failures
+      expr: |2-
+          rate(
+            thanos_operator_store_shards_creation_update_failures_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+          )
+        >
+          0
+      for: 5m
+      labels:
+        component: thanos-store
+        service: thanos-operator
+        severity: critical
+    - alert: ThanosStoreReconcileErrors
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosStore controller has {{ $value | humanize }} errors/sec
+        message: ThanosStore resources may not be properly configured or updated.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosstorereconcileerrors
+        summary: ThanosStore controller experiencing reconciliation errors
+      expr: |2-
+          rate(
+            controller_runtime_reconcile_errors_total{controller="thanosstore",job="thanos-operator-controller-manager-metrics-service"}[10m]
+          )
+        >
+          0
+      for: 15m
+      labels:
+        component: thanos-store
+        service: thanos-operator
+        severity: warning
+  - interval: 30s
+    name: thanos-operator.compact
+    rules:
+    - alert: ThanosCompactNoShardsConfigured
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosCompact resource {{ $labels.namespace }}/{{ $labels.resource
+          }} has 0 shards configured.
+        message: This may be expected for single-instance compactors. For sharded
+          deployments, compaction may not work.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanoscompactnoshardsconfigured
+        summary: ThanosCompact {{ $labels.namespace }}/{{ $labels.resource }} has
+          no shards configured
+      expr: |2-
+          thanos_operator_compact_shards_configured{job="thanos-operator-controller-manager-metrics-service"}
+        ==
+          0
+      for: 10m
+      labels:
+        component: thanos-compact
+        service: thanos-operator
+        severity: info
+    - alert: ThanosCompactShardCreationFailures
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosCompact controller is failing to create/update shards for
+          {{ $labels.namespace }}/{{ $labels.resource }}.
+        message: Compactor shards cannot be created. Data compaction will not occur,
+          leading to increased storage costs and slower queries.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanoscompactshardcreationfailures
+        summary: ThanosCompact {{ $labels.namespace }}/{{ $labels.resource }} shard
+          creation/update failures
+      expr: |2-
+          rate(
+            thanos_operator_compact_shards_creation_update_failures_total{job="thanos-operator-controller-manager-metrics-service"}[5m]
+          )
+        >
+          0
+      for: 5m
+      labels:
+        component: thanos-compact
+        service: thanos-operator
+        severity: critical
+    - alert: ThanosCompactReconcileErrors
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: ThanosCompact controller has {{ $value | humanize }} errors/sec
+        message: ThanosCompact resources may not be properly configured or updated.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanoscompactreconcileerrors
+        summary: ThanosCompact controller experiencing reconciliation errors
+      expr: |2-
+          rate(
+            controller_runtime_reconcile_errors_total{controller="thanoscompact",job="thanos-operator-controller-manager-metrics-service"}[10m]
+          )
+        >
+          0
+      for: 15m
+      labels:
+        component: thanos-compact
+        service: thanos-operator
+        severity: warning
+  - interval: 30s
+    name: thanos-operator.paused
+    rules:
+    - alert: ThanosResourcePausedForLong
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: '{{ $labels.component }} resource {{ $labels.namespace }}/{{
+          $labels.resource }} has been in paused state for over 24 hours.'
+        message: No reconciliation is happening for this resource. Configuration changes
+          are not being applied.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosresourcepausedforlong
+        summary: Thanos resource {{ $labels.namespace }}/{{ $labels.resource }} has
+          been paused for 24+ hours
+      expr: thanos_operator_paused{job="thanos-operator-controller-manager-metrics-service"}
+        == 1
+      for: 24h
+      labels:
+        component: '{{ $labels.component }}'
+        controller: '{{ $labels.controller }}'
+        service: thanos-operator
+        severity: info
+  - interval: 30s
+    name: thanos-operator.workqueue
+    rules:
+    - alert: ThanosOperatorHighWorkqueueRetries
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: Workqueue {{ $labels.name }} has {{ $value | humanize }} retries/sec.
+        message: Items are being retried frequently, indicating persistent errors
+          or resource issues.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosoperatorhighworkqueueretries
+        summary: High retry rate for workqueue {{ $labels.name }}
+      expr: rate(workqueue_retries_total{job="thanos-operator-controller-manager-metrics-service"}[10m])
+        > 0.5
+      for: 15m
+      labels:
+        component: thanos-operator
+        controller: '{{ $labels.controller }}'
+        service: thanos-operator
+        severity: warning
+    - alert: ThanosOperatorLongWorkqueueLatency
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosoperator
+        description: P99 queue wait time for {{ $labels.name }} is {{ $value | humanizeDuration
+          }}.
+        message: Items are waiting too long in queue before processing. Reconciliation
+          is delayed.
+        runbook: https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md#thanosoperatorlongworkqueuelatency
+        summary: High queue latency for workqueue {{ $labels.name }}
+      expr: |2-
+          histogram_quantile(
+            0.99,
+            rate(
+              workqueue_queue_duration_seconds_bucket{job="thanos-operator-controller-manager-metrics-service"}[10m]
+            )
+          )
+        >
+          60
+      for: 10m
+      labels:
+        component: thanos-operator
+        controller: '{{ $labels.controller }}'
+        service: thanos-operator
+        severity: warning

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/perses/community-mixins/pkg/rules"
 	blackboxrules "github.com/perses/community-mixins/pkg/rules/blackbox"
 	thanosrules "github.com/perses/community-mixins/pkg/rules/thanos"
+	thanosoperatorrules "github.com/perses/community-mixins/pkg/rules/thanos-operator"
 )
 
 var (
@@ -70,9 +71,24 @@ func main() {
 				thanosrules.WithRuleDashboardURL("https://demo.perses.dev/projects/perses/dashboards/thanosrule"),
 			),
 		)
+		ruleWriter.Add(
+			thanosoperatorrules.BuildThanosOperatorRules(
+				project,
+				map[string]string{
+					"app.kubernetes.io/component": "thanos-operator",
+					"app.kubernetes.io/name":      "thanos-operator-rules",
+					"app.kubernetes.io/part-of":   "thanos-operator",
+					"app.kubernetes.io/version":   "main",
+				},
+				map[string]string{},
+				thanosoperatorrules.WithRunbookURL("https://github.com/thanos-community/thanos-operator/blob/main/mixin/runbook.md"),
+				thanosoperatorrules.WithDashboardURL("https://demo.perses.dev/projects/perses/dashboards/thanosoperator"),
+				thanosoperatorrules.WithServiceLabelValue("thanos-operator"),
+			),
+		)
 		ruleWriter.Add(blackboxrules.BuildBlackboxRulesDefault(project))
-		ruleWriter.Write()
 
+		ruleWriter.Write()
 	} else {
 		dashboardWriter := dashboards.NewDashboardWriter()
 

--- a/pkg/rules/thanos-operator/thanos-operator.go
+++ b/pkg/rules/thanos-operator/thanos-operator.go
@@ -1,0 +1,1431 @@
+package thanosoperator
+
+import (
+	"time"
+
+	promqlbuilder "github.com/perses/promql-builder"
+	"github.com/perses/promql-builder/label"
+	"github.com/perses/promql-builder/matrix"
+	"github.com/perses/promql-builder/vector"
+
+	rulehelpers "github.com/perses/community-mixins/pkg/rules"
+	"github.com/perses/community-mixins/pkg/rules/rule-sdk/alerting"
+	"github.com/perses/community-mixins/pkg/rules/rule-sdk/common"
+	"github.com/perses/community-mixins/pkg/rules/rule-sdk/promtheusrule"
+	"github.com/perses/community-mixins/pkg/rules/rule-sdk/rulegroup"
+)
+
+// Runbook fragments
+const (
+	runbookThanosOperatorDown                       = "#thanosoperatordown"
+	runbookThanosOperatorHighReconcileErrorRate     = "#thanosoperatorhighreconcileerrorrate"
+	runbookThanosOperatorReconcileStuck             = "#thanosoperatorreconcilestuck"
+	runbookThanosOperatorWorkQueueGrowth            = "#thanosoperatorworkqueuegrowth"
+	runbookThanosOperatorSlowReconciliation         = "#thanosoperatorslowreconciliation"
+	runbookThanosQueryNoEndpointsConfigured         = "#thanosquerynoendpointsconfigured"
+	runbookThanosQueryReconcileErrors               = "#thanosqueryreconcileerrors"
+	runbookThanosQueryServiceWatchReconcileStorm    = "#thanosqueryservicewatchreconcilestorm"
+	runbookThanosReceiveNoHashringsConfigured       = "#thanosreceivenohashringsconfigured"
+	runbookThanosReceiveHashringNoEndpoints         = "#thanosreceivehashringnoendpoints"
+	runbookThanosReceiveHashringConfigurationChange = "#thanosreceivehashringconfigurationchange"
+	runbookThanosReceiveReconcileErrors             = "#thanosreceivereconcileerrors"
+	runbookThanosReceiveEndpointReconcileStorm      = "#thanosreceiveendpointreconcilestorm"
+	runbookThanosRulerNoQueryEndpointsConfigured    = "#thanosrulernoqueryendpointsconfigured"
+	runbookThanosRulerNoRulesConfigured             = "#thanosrulernorulesconfigured"
+	runbookThanosRulerConfigMapCreationFailures     = "#thanosrulerconfigmapcreationfailures"
+	runbookThanosRulerHighConfigMapCreationRate     = "#thanosrulerhighconfigmapcreationrate"
+	runbookThanosRulerReconcileErrors               = "#thanosrulerreconcileerrors"
+	runbookThanosRulerWatchReconcileStorm           = "#thanosrulerwatchreconcilestorm"
+	runbookThanosStoreNoShardsConfigured            = "#thanosstenoreshardsconfigured"
+	runbookThanosStoreShardCreationFailures         = "#thanosstoreshardcreationfailures"
+	runbookThanosStoreReconcileErrors               = "#thanosstorereconcileerrors"
+	runbookThanosCompactNoShardsConfigured          = "#thanoscompactnoshardsconfigured"
+	runbookThanosCompactShardCreationFailures       = "#thanoscompactshardcreationfailures"
+	runbookThanosCompactReconcileErrors             = "#thanoscompactreconcileerrors"
+	runbookThanosResourcePausedForLong              = "#thanosresourcepausedforlong"
+	runbookThanosOperatorHighWorkqueueRetries       = "#thanosoperatorhighworkqueueretries"
+	runbookThanosOperatorLongWorkqueueLatency       = "#thanosoperatorlongworkqueuelatency"
+)
+
+type ThanosOperatorRulesConfig struct {
+	RunbookURL                 string
+	DashboardURL               string
+	ServiceLabelValue          string
+	AdditionalAlertLabels      map[string]string
+	AdditionalAlertAnnotations map[string]string
+}
+
+type ThanosOperatorRulesConfigOption func(*ThanosOperatorRulesConfig)
+
+func WithRunbookURL(runbookURL string) ThanosOperatorRulesConfigOption {
+	return func(config *ThanosOperatorRulesConfig) {
+		config.RunbookURL = runbookURL
+	}
+}
+
+func WithDashboardURL(dashboardURL string) ThanosOperatorRulesConfigOption {
+	return func(config *ThanosOperatorRulesConfig) {
+		config.DashboardURL = dashboardURL
+	}
+}
+
+func WithServiceLabelValue(serviceLabelValue string) ThanosOperatorRulesConfigOption {
+	return func(config *ThanosOperatorRulesConfig) {
+		config.ServiceLabelValue = serviceLabelValue
+	}
+}
+
+func WithAdditionalAlertLabels(additionalAlertLabels map[string]string) ThanosOperatorRulesConfigOption {
+	return func(config *ThanosOperatorRulesConfig) {
+		config.AdditionalAlertLabels = additionalAlertLabels
+	}
+}
+
+func WithAdditionalAlertAnnotations(additionalAlertAnnotations map[string]string) ThanosOperatorRulesConfigOption {
+	return func(config *ThanosOperatorRulesConfig) {
+		config.AdditionalAlertAnnotations = additionalAlertAnnotations
+	}
+}
+
+// BuildThanosOperatorRules builds the Thanos Operator rules
+func BuildThanosOperatorRules(
+	namespace string,
+	labels map[string]string,
+	annotations map[string]string,
+	options ...ThanosOperatorRulesConfigOption,
+) rulehelpers.RuleResult {
+	config := ThanosOperatorRulesConfig{}
+	for _, option := range options {
+		option(&config)
+	}
+
+	promRule, err := promtheusrule.New(
+		"thanos-operator-alerts",
+		namespace,
+		promtheusrule.Labels(labels),
+		promtheusrule.Annotations(annotations),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.general",
+			config.ThanosOperatorGeneralGroup()...,
+		),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.query",
+			config.ThanosOperatorQueryGroup()...,
+		),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.receive",
+			config.ThanosOperatorReceiveGroup()...,
+		),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.ruler",
+			config.ThanosOperatorRulerGroup()...,
+		),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.store",
+			config.ThanosOperatorStoreGroup()...,
+		),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.compact",
+			config.ThanosOperatorCompactGroup()...,
+		),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.paused",
+			config.ThanosOperatorPausedGroup()...,
+		),
+		promtheusrule.AddRuleGroup(
+			"thanos-operator.workqueue",
+			config.ThanosOperatorWorkqueueGroup()...,
+		),
+	)
+
+	if err != nil {
+		return rulehelpers.NewRuleResult(nil, err).Component("thanos-operator")
+	}
+
+	return rulehelpers.NewRuleResult(
+		&promRule.PrometheusRule,
+		nil,
+	).Component("thanos-operator")
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorGeneralGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosOperatorDown",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("up"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("5m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "critical",
+						"component": "thanos-operator",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosOperatorDown,
+						"The Thanos Operator has been down for more than 5 minutes. No reconciliation is happening.",
+						"Thanos resources are not being reconciled. Configuration changes will not be applied.",
+						"Thanos Operator is down",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosOperatorHighReconcileErrorRate",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Div(
+						promqlbuilder.Sum(
+							promqlbuilder.Rate(
+								matrix.New(
+									vector.New(
+										vector.WithMetricName("controller_runtime_reconcile_errors_total"),
+										vector.WithLabelMatchers(
+											label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+										),
+									),
+									matrix.WithRange(5*time.Minute),
+								),
+							),
+						).By("controller"),
+						promqlbuilder.Sum(
+							promqlbuilder.Rate(
+								matrix.New(
+									vector.New(
+										vector.WithMetricName("controller_runtime_reconcile_total"),
+										vector.WithLabelMatchers(
+											label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+										),
+									),
+									matrix.WithRange(5*time.Minute),
+								),
+							),
+						).By("controller"),
+					),
+					promqlbuilder.NewNumber(0.1),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":    t.ServiceLabelValue,
+						"severity":   "warning",
+						"component":  "thanos-operator",
+						"controller": "{{ $labels.controller }}",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosOperatorHighReconcileErrorRate,
+						"Controller {{ $labels.controller }} has an error rate of {{ $value | humanizePercentage }} over the last 10 minutes.",
+						"Resources managed by this controller may not be correctly configured or updated.",
+						"High reconciliation error rate for {{ $labels.controller }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosOperatorReconcileStuck",
+			alerting.Expr(
+				promqlbuilder.And(
+					promqlbuilder.Eqlc(
+						promqlbuilder.Rate(
+							matrix.New(
+								vector.New(
+									vector.WithMetricName("controller_runtime_reconcile_total"),
+									vector.WithLabelMatchers(
+										label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+									),
+								),
+								matrix.WithRange(10*time.Minute),
+							),
+						),
+						promqlbuilder.NewNumber(0),
+					),
+					promqlbuilder.Gtr(
+						vector.New(
+							vector.WithMetricName("workqueue_depth"),
+							vector.WithLabelMatchers(
+								label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+							),
+						),
+						promqlbuilder.NewNumber(0),
+					),
+				).On("controller", "job"),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":    t.ServiceLabelValue,
+						"severity":   "warning",
+						"component":  "thanos-operator",
+						"controller": "{{ $labels.controller }}",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosOperatorReconcileStuck,
+						"Workqueue for {{ $labels.name }} has items but no reconciliations are happening.",
+						"Changes to Thanos resources are not being processed.",
+						"Controller {{ $labels.name }} appears stuck",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosOperatorWorkQueueGrowth",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					vector.New(
+						vector.WithMetricName("workqueue_depth"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(100),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":    t.ServiceLabelValue,
+						"severity":   "warning",
+						"component":  "thanos-operator",
+						"controller": "{{ $labels.controller }}",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosOperatorWorkQueueGrowth,
+						"Workqueue depth for {{ $labels.name }} is {{ $value }}, indicating the controller cannot keep up with events.",
+						"Reconciliation is falling behind. Configuration updates may be delayed.",
+						"Controller workqueue {{ $labels.name }} is growing",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosOperatorSlowReconciliation",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.HistogramQuantile(
+						0.99,
+						promqlbuilder.Rate(
+							matrix.New(
+								vector.New(
+									vector.WithMetricName("controller_runtime_reconcile_time_seconds_bucket"),
+									vector.WithLabelMatchers(
+										label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+									),
+								),
+								matrix.WithRange(10*time.Minute),
+							),
+						),
+					),
+					promqlbuilder.NewNumber(60),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":    t.ServiceLabelValue,
+						"severity":   "warning",
+						"component":  "thanos-operator",
+						"controller": "{{ $labels.controller }}",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosOperatorSlowReconciliation,
+						"P99 reconciliation time for {{ $labels.controller }} is {{ $value | humanizeDuration }}",
+						"Configuration changes are taking longer than expected to apply.",
+						"Slow reconciliation for {{ $labels.controller }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorQueryGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosQueryNoEndpointsConfigured",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_query_endpoints_configured"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-query",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosQueryNoEndpointsConfigured,
+						"ThanosQuery resource {{ $labels.namespace }}/{{ $labels.resource }} has no store endpoints configured.",
+						"Query component cannot retrieve data from any stores. Queries will return no results.",
+						"ThanosQuery {{ $labels.namespace }}/{{ $labels.resource }} has no endpoints configured",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosQueryReconcileErrors",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("controller_runtime_reconcile_errors_total"),
+								vector.WithLabelMatchers(
+									label.New("controller").Equal("thanosquery"),
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(10*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-query",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosQueryReconcileErrors,
+						"ThanosQuery controller has {{ $value | humanize }} errors/sec",
+						"ThanosQuery resources may not be properly configured or updated.",
+						"ThanosQuery controller experiencing reconciliation errors",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosQueryServiceWatchReconcileStorm",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("thanos_operator_query_service_event_reconciliations_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(5*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(2),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-query",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosQueryServiceWatchReconcileStorm,
+						"ThanosQuery {{ $labels.namespace }}/{{ $labels.resource }} is reconciling {{ $value | humanize }} times/sec due to service events.",
+						"Excessive reconciliations may indicate service churn or configuration issues.",
+						"High service watch reconciliation rate for ThanosQuery {{ $labels.namespace }}/{{ $labels.resource }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorReceiveGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosReceiveNoHashringsConfigured",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_receive_hashrings_configured"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-receive",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosReceiveNoHashringsConfigured,
+						"ThanosReceive resource {{ $labels.namespace }}/{{ $labels.resource }} has no hashrings configured.",
+						"Receive component cannot accept remote write data without hashring configuration.",
+						"ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }} has no hashrings configured",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosReceiveHashringNoEndpoints",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_receive_hashring_endpoints_configured"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "critical",
+						"component": "thanos-receive",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosReceiveHashringNoEndpoints,
+						"Hashring {{ $labels.hashring }} for ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }} has no endpoints configured.",
+						"Data cannot be distributed to this hashring. Remote write data may be lost or rejected.",
+						"ThanosReceive hashring {{ $labels.hashring }} has no endpoints",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosReceiveHashringConfigurationChange",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Abs(
+						promqlbuilder.Delta(
+							matrix.New(
+								vector.New(
+									vector.WithMetricName("thanos_operator_receive_hashring_hash"),
+									vector.WithLabelMatchers(
+										label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+									),
+								),
+								matrix.WithRange(5*time.Minute),
+							),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("0m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "info",
+						"component": "thanos-receive",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosReceiveHashringConfigurationChange,
+						"The hashring configuration for ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }} has changed.",
+						"Data distribution pattern has changed. This may cause temporary inconsistencies.",
+						"ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }} hashring configuration changed",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosReceiveReconcileErrors",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("controller_runtime_reconcile_errors_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+									label.New("controller").Equal("thanosreceive"),
+								),
+							),
+							matrix.WithRange(10*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-receive",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosReceiveReconcileErrors,
+						"ThanosReceive controller has {{ $value | humanize }} errors/sec",
+						"ThanosReceive resources may not be properly configured or updated.",
+						"ThanosReceive controller experiencing reconciliation errors",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosReceiveEndpointReconcileStorm",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("thanos_operator_receive_endpoint_event_reconciliations_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(5*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(2),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-receive",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosReceiveEndpointReconcileStorm,
+						"ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }} is reconciling {{ $value | humanize }} times/sec due to endpoint events.",
+						"Excessive reconciliations may indicate endpoint churn or configuration issues.",
+						"High endpoint watch reconciliation rate for ThanosReceive {{ $labels.namespace }}/{{ $labels.resource }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorRulerGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosRulerNoQueryEndpointsConfigured",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_ruler_query_endpoints_configured"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-ruler",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosRulerNoQueryEndpointsConfigured,
+						"ThanosRuler resource {{ $labels.namespace }}/{{ $labels.resource }} has no query endpoints configured.",
+						"Ruler cannot query data for rule evaluation. Recording and alerting rules will not work.",
+						"ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} has no query endpoints configured",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosRulerNoRulesConfigured",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_ruler_promrules_found"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "info",
+						"component": "thanos-ruler",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosRulerNoRulesConfigured,
+						"No PrometheusRules found for ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }}.",
+						"No rules are being evaluated. This may be expected if no rules have been defined yet.",
+						"ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} has no PrometheusRules",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosRulerConfigMapCreationFailures",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("thanos_operator_ruler_cfgmaps_creation_failures_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(5*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("5m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "critical",
+						"component": "thanos-ruler",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosRulerConfigMapCreationFailures,
+						"ThanosRuler controller is failing to create ConfigMaps for {{ $labels.namespace }}/{{ $labels.resource }}.",
+						"PrometheusRules cannot be loaded into the Ruler. Rules will not be evaluated.",
+						"ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} failing to create ConfigMaps",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosRulerHighConfigMapCreationRate",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("thanos_operator_ruler_cfgmaps_created_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(5*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(1),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-ruler",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosRulerHighConfigMapCreationRate,
+						"ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} is creating ConfigMaps at {{ $value | humanize }}/sec.",
+						"Excessive ConfigMap updates may indicate rule churn and cause unnecessary Ruler reloads.",
+						"High ConfigMap creation rate for ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosRulerReconcileErrors",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("controller_runtime_reconcile_errors_total"),
+								vector.WithLabelMatchers(
+									label.New("controller").Equal("thanosruler"),
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(10*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-ruler",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosRulerReconcileErrors,
+						"ThanosRuler controller has {{ $value | humanize }} errors/sec",
+						"ThanosRuler resources may not be properly configured or updated.",
+						"ThanosRuler controller experiencing reconciliation errors",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosRulerWatchReconcileStorm",
+			alerting.Expr(
+				promqlbuilder.Or(
+					promqlbuilder.Or(
+						promqlbuilder.Gtr(
+							promqlbuilder.Rate(
+								matrix.New(
+									vector.New(
+										vector.WithMetricName("thanos_operator_ruler_service_event_reconciliations_total"),
+										vector.WithLabelMatchers(
+											label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+										),
+									),
+									matrix.WithRange(5*time.Minute),
+								),
+							),
+							promqlbuilder.NewNumber(2),
+						),
+						promqlbuilder.Gtr(
+							promqlbuilder.Rate(
+								matrix.New(
+									vector.New(
+										vector.WithMetricName("thanos_operator_ruler_cfgmap_event_reconciliations_total"),
+										vector.WithLabelMatchers(
+											label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+										),
+									),
+									matrix.WithRange(5*time.Minute),
+								),
+							),
+							promqlbuilder.NewNumber(2),
+						),
+					),
+					promqlbuilder.Gtr(
+						promqlbuilder.Rate(
+							matrix.New(
+								vector.New(
+									vector.WithMetricName("thanos_operator_ruler_promrule_event_reconciliations_total"),
+									vector.WithLabelMatchers(
+										label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+									),
+								),
+								matrix.WithRange(5*time.Minute),
+							),
+						),
+						promqlbuilder.NewNumber(2),
+					),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-ruler",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosRulerWatchReconcileStorm,
+						"ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }} is experiencing high reconciliation rate.",
+						"Excessive reconciliations may indicate resource churn or configuration issues.",
+						"High watch reconciliation rate for ThanosRuler {{ $labels.namespace }}/{{ $labels.resource }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorStoreGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosStoreNoShardsConfigured",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_store_shards_configured"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "info",
+						"component": "thanos-store",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosStoreNoShardsConfigured,
+						"ThanosStore resource {{ $labels.namespace }}/{{ $labels.resource }} has 0 shards configured.",
+						"This may be expected for single-instance stores. For sharded deployments, data queries may fail.",
+						"ThanosStore {{ $labels.namespace }}/{{ $labels.resource }} has no shards configured",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosStoreShardCreationFailures",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("thanos_operator_store_shards_creation_update_failures_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(5*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("5m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "critical",
+						"component": "thanos-store",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosStoreShardCreationFailures,
+						"ThanosStore controller is failing to create/update shards for {{ $labels.namespace }}/{{ $labels.resource }}.",
+						"Store shards cannot be created. Historical data queries may be incomplete or fail.",
+						"ThanosStore {{ $labels.namespace }}/{{ $labels.resource }} shard creation/update failures",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosStoreReconcileErrors",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("controller_runtime_reconcile_errors_total"),
+								vector.WithLabelMatchers(
+									label.New("controller").Equal("thanosstore"),
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(10*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-store",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosStoreReconcileErrors,
+						"ThanosStore controller has {{ $value | humanize }} errors/sec",
+						"ThanosStore resources may not be properly configured or updated.",
+						"ThanosStore controller experiencing reconciliation errors",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorCompactGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosCompactNoShardsConfigured",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_compact_shards_configured"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "info",
+						"component": "thanos-compact",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosCompactNoShardsConfigured,
+						"ThanosCompact resource {{ $labels.namespace }}/{{ $labels.resource }} has 0 shards configured.",
+						"This may be expected for single-instance compactors. For sharded deployments, compaction may not work.",
+						"ThanosCompact {{ $labels.namespace }}/{{ $labels.resource }} has no shards configured",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosCompactShardCreationFailures",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("thanos_operator_compact_shards_creation_update_failures_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(5*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("5m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "critical",
+						"component": "thanos-compact",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosCompactShardCreationFailures,
+						"ThanosCompact controller is failing to create/update shards for {{ $labels.namespace }}/{{ $labels.resource }}.",
+						"Compactor shards cannot be created. Data compaction will not occur, leading to increased storage costs and slower queries.",
+						"ThanosCompact {{ $labels.namespace }}/{{ $labels.resource }} shard creation/update failures",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosCompactReconcileErrors",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("controller_runtime_reconcile_errors_total"),
+								vector.WithLabelMatchers(
+									label.New("controller").Equal("thanoscompact"),
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(10*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":   t.ServiceLabelValue,
+						"severity":  "warning",
+						"component": "thanos-compact",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosCompactReconcileErrors,
+						"ThanosCompact controller has {{ $value | humanize }} errors/sec",
+						"ThanosCompact resources may not be properly configured or updated.",
+						"ThanosCompact controller experiencing reconciliation errors",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorPausedGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosResourcePausedForLong",
+			alerting.Expr(
+				promqlbuilder.Eqlc(
+					vector.New(
+						vector.WithMetricName("thanos_operator_paused"),
+						vector.WithLabelMatchers(
+							label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+						),
+					),
+					promqlbuilder.NewNumber(1),
+				),
+			),
+			alerting.For("24h"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":    t.ServiceLabelValue,
+						"severity":   "info",
+						"component":  "{{ $labels.component }}",
+						"controller": "{{ $labels.controller }}",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosResourcePausedForLong,
+						"{{ $labels.component }} resource {{ $labels.namespace }}/{{ $labels.resource }} has been in paused state for over 24 hours.",
+						"No reconciliation is happening for this resource. Configuration changes are not being applied.",
+						"Thanos resource {{ $labels.namespace }}/{{ $labels.resource }} has been paused for 24+ hours",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}
+
+func (t ThanosOperatorRulesConfig) ThanosOperatorWorkqueueGroup() []rulegroup.Option {
+	return []rulegroup.Option{
+		rulegroup.Interval("30s"),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosOperatorHighWorkqueueRetries",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Rate(
+						matrix.New(
+							vector.New(
+								vector.WithMetricName("workqueue_retries_total"),
+								vector.WithLabelMatchers(
+									label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+								),
+							),
+							matrix.WithRange(10*time.Minute),
+						),
+					),
+					promqlbuilder.NewNumber(0.5),
+				),
+			),
+			alerting.For("15m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":    t.ServiceLabelValue,
+						"severity":   "warning",
+						"component":  "thanos-operator",
+						"controller": "{{ $labels.controller }}",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosOperatorHighWorkqueueRetries,
+						"Workqueue {{ $labels.name }} has {{ $value | humanize }} retries/sec.",
+						"Items are being retried frequently, indicating persistent errors or resource issues.",
+						"High retry rate for workqueue {{ $labels.name }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule[alerting.Option](
+			"ThanosOperatorLongWorkqueueLatency",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.HistogramQuantile(
+						0.99,
+						promqlbuilder.Rate(
+							matrix.New(
+								vector.New(
+									vector.WithMetricName("workqueue_queue_duration_seconds_bucket"),
+									vector.WithLabelMatchers(
+										label.New("job").Equal("thanos-operator-controller-manager-metrics-service"),
+									),
+								),
+								matrix.WithRange(10*time.Minute),
+							),
+						),
+					),
+					promqlbuilder.NewNumber(60),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":    t.ServiceLabelValue,
+						"severity":   "warning",
+						"component":  "thanos-operator",
+						"controller": "{{ $labels.controller }}",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.DashboardURL,
+						t.RunbookURL,
+						runbookThanosOperatorLongWorkqueueLatency,
+						"P99 queue wait time for {{ $labels.name }} is {{ $value | humanizeDuration }}.",
+						"Items are waiting too long in queue before processing. Reconciliation is delayed.",
+						"High queue latency for workqueue {{ $labels.name }}",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+	}
+}


### PR DESCRIPTION
This commit adds alerting rules for Thanos Operator.

Thanos Operator is a relatively new project at the moment, but under active dev, and near a v0.1 release, wanted to include it here as well.

Check it out at https://github.com/thanos-community/thanos-operator