### PR TITLE
rules: Fix missing parenthesis on Thanos & Alertmanager rules

### DIFF
--- a/examples/rules/operator/alertmanager/alertmanager-rules.yaml
+++ b/examples/rules/operator/alertmanager/alertmanager-rules.yaml
@@ -48,9 +48,11 @@ spec:
         runbook: https://github.com/prometheus/alertmanager/blob/main/doc/alertmanager-mixin/README.md#alertmanagerfailedtosendalerts
         summary: An Alertmanager instance failed to send notifications.
       expr: |2-
-            rate(alertmanager_notifications_failed_total{job="alertmanager"}[15m])
-          / ignoring (reason) group_left ()
-            rate(alertmanager_notifications_total{job="alertmanager"}[15m])
+          (
+              rate(alertmanager_notifications_failed_total{job="alertmanager"}[15m])
+            / ignoring (reason) group_left ()
+              rate(alertmanager_notifications_total{job="alertmanager"}[15m])
+          )
         >
           0.01
       for: 5m
@@ -124,9 +126,11 @@ spec:
         summary: Half or more of the Alertmanager instances within the same cluster
           are down.
       expr: |2-
-            count by (job) (avg_over_time(up{job="alertmanager"}[5m]) < 0.5)
-          /
-            count by (job) (up{job="alertmanager"})
+          (
+              count by (job) (avg_over_time(up{job="alertmanager"}[5m]) < 0.5)
+            /
+              count by (job) (up{job="alertmanager"})
+          )
         >=
           0.5
       for: 5m
@@ -143,9 +147,11 @@ spec:
         summary: Half or more of the Alertmanager instances within the same cluster
           are crashlooping.
       expr: |2-
-            count by (job) (changes(process_start_time_seconds{job="alertmanager"}[10m]) > 4)
-          /
-            count by (job) (up{job="alertmanager"})
+          (
+              count by (job) (changes(process_start_time_seconds{job="alertmanager"}[10m]) > 4)
+            /
+              count by (job) (up{job="alertmanager"})
+          )
         >=
           0.5
       for: 5m

--- a/examples/rules/operator/thanos/thanos-rules.yaml
+++ b/examples/rules/operator/thanos/thanos-rules.yaml
@@ -118,11 +118,13 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanoscompacthighcompactionfailures
         summary: Thanos Compact is failing to execute compactions.
       expr: |2-
-              sum by (namespace, job) (
-                rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m])
-              )
-            /
-              sum by (namespace, job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
+            (
+                sum by (namespace, job) (
+                  rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m])
+                )
+              /
+                sum by (namespace, job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
+            )
           *
             100
         >
@@ -139,11 +141,13 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanoscompactbuckethighoperationfailures
         summary: Thanos Compact Bucket is having a high number of operation failures.
       expr: |2-
-              sum by (namespace, job) (
-                rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m])
-              )
-            /
-              sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
+            (
+                sum by (namespace, job) (
+                  rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m])
+                )
+              /
+                sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
+            )
           *
             100
         >
@@ -160,11 +164,13 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanoscompacthasnotrun
         summary: Thanos Compact has not uploaded anything for last 24 hours.
       expr: |2-
-                time()
-              -
-                max by (namespace, job) (
-                  max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}[1d])
-                )
+              (
+                  time()
+                -
+                  max by (namespace, job) (
+                    max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}[1d])
+                  )
+              )
             /
               60
           /
@@ -185,11 +191,13 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosqueryhttprequestqueryerrorratehigh
         summary: Thanos Query is failing to handle requests.
       expr: |2-
-              sum by (namespace, job) (
-                rate(http_requests_total{code=~"5..",handler="query",job=~"thanos-query.*"}[5m])
-              )
-            /
-              sum by (namespace, job) (rate(http_requests_total{handler="query",job=~"thanos-query.*"}[5m]))
+            (
+                sum by (namespace, job) (
+                  rate(http_requests_total{code=~"5..",handler="query",job=~"thanos-query.*"}[5m])
+                )
+              /
+                sum by (namespace, job) (rate(http_requests_total{handler="query",job=~"thanos-query.*"}[5m]))
+            )
           *
             100
         >
@@ -206,13 +214,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosquerygrpcservererrorrate
         summary: Thanos Query is failing to handle requests.
       expr: |2-
-              sum by (namespace, job) (
-                rate(
-                  grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-query.*"}[5m]
+            (
+                sum by (namespace, job) (
+                  rate(
+                    grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-query.*"}[5m]
+                  )
                 )
-              )
-            /
-              sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
+              /
+                sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
+            )
           *
             100
         >
@@ -229,9 +239,11 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosquerygrpcclienterrorrate
         summary: Thanos Query is failing to send requests.
       expr: |2-
-              sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code!="OK",job=~"thanos-query.*"}[5m]))
-            /
-              sum by (namespace, job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
+            (
+                sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code!="OK",job=~"thanos-query.*"}[5m]))
+              /
+                sum by (namespace, job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
+            )
           *
             100
         >
@@ -248,11 +260,13 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosqueryhighdnsfailures
         summary: Thanos Query is having high number of DNS failures.
       expr: |2-
-              sum by (namespace, job) (
-                rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m])
-              )
-            /
-              sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+            (
+                sum by (namespace, job) (
+                  rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m])
+                )
+              /
+                sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+            )
           *
             100
         >
@@ -297,13 +311,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivehttprequesterrorratehigh
         summary: Thanos Receive is failing to handle requests.
       expr: |2-
-              sum by (namespace, job) (
-                rate(http_requests_total{code=~"5..",handler="receive",job=~"thanos-receive-router.*"}[5m])
-              )
-            /
-              sum by (namespace, job) (
-                rate(http_requests_total{handler="receive",job=~"thanos-receive-router.*"}[5m])
-              )
+            (
+                sum by (namespace, job) (
+                  rate(http_requests_total{code=~"5..",handler="receive",job=~"thanos-receive-router.*"}[5m])
+                )
+              /
+                sum by (namespace, job) (
+                  rate(http_requests_total{handler="receive",job=~"thanos-receive-router.*"}[5m])
+                )
+            )
           *
             100
         >
@@ -348,21 +364,27 @@ spec:
       expr: |2-
           thanos_receive_replication_factor > 1
         and
-                sum by (namespace, job) (
-                  rate(thanos_receive_replications_total{job=~"thanos-receive-router.*",result="error"}[5m])
+          (
+                (
+                    sum by (namespace, job) (
+                      rate(thanos_receive_replications_total{job=~"thanos-receive-router.*",result="error"}[5m])
+                    )
+                  /
+                    sum by (namespace, job) (
+                      rate(thanos_receive_replications_total{job=~"thanos-receive-router.*"}[5m])
+                    )
                 )
-              /
-                sum by (namespace, job) (
-                  rate(thanos_receive_replications_total{job=~"thanos-receive-router.*"}[5m])
+              >
+                (
+                    max by (namespace, job) (
+                      floor(thanos_receive_replication_factor{job=~"thanos-receive-router.*"} + 1 / 2)
+                    )
+                  /
+                    max by (namespace, job) (thanos_receive_hashring_nodes{job=~"thanos-receive-router.*"})
                 )
-            >
-                max by (namespace, job) (
-                  floor(thanos_receive_replication_factor{job=~"thanos-receive-router.*"} + 1 / 2)
-                )
-              /
-                max by (namespace, job) (thanos_receive_hashring_nodes{job=~"thanos-receive-router.*"})
-          *
-            100
+            *
+              100
+          )
       for: 5m
       labels:
         service: thanos
@@ -375,13 +397,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivehighforwardrequestfailures
         summary: Thanos Receive is failing to forward requests.
       expr: |2-
-              sum by (namespace, job) (
-                rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*",result="error"}[5m])
-              )
-            /
-              sum by (namespace, job) (
-                rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*"}[5m])
-              )
+            (
+                sum by (namespace, job) (
+                  rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*",result="error"}[5m])
+                )
+              /
+                sum by (namespace, job) (
+                  rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*"}[5m])
+                )
+            )
           *
             100
         >
@@ -398,13 +422,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivehighhashringfilerefreshfailures
         summary: Thanos Receive is failing to refresh hasring file.
       expr: |2-
-            sum by (namespace, job) (
-              rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive-router.*"}[5m])
-            )
-          /
-            sum by (namespace, job) (
-              rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive-router.*"}[5m])
-            )
+          (
+              sum by (namespace, job) (
+                rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive-router.*"}[5m])
+              )
+            /
+              sum by (namespace, job) (
+                rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive-router.*"}[5m])
+              )
+          )
         >
           0
       for: 15m
@@ -436,13 +462,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivenoupload
         summary: Thanos Receive has not uploaded latest data to object storage.
       expr: |2-
-          up{job=~"thanos-receive-ingester.*"} - 1
+          (up{job=~"thanos-receive-ingester.*"} - 1)
         + on (namespace, job, instance)
-            sum by (namespace, job, instance) (
-              increase(thanos_shipper_uploads_total{job=~"thanos-receive-ingester.*"}[3h])
-            )
-          ==
-            0
+          (
+              sum by (namespace, job, instance) (
+                increase(thanos_shipper_uploads_total{job=~"thanos-receive-ingester.*"}[3h])
+              )
+            ==
+              0
+          )
       for: 3h
       labels:
         service: thanos
@@ -512,13 +540,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosstoregrpcerrorrate
         summary: Thanos Store is failing to handle gRPC requests.
       expr: |2-
-              sum by (namespace, job) (
-                rate(
-                  grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-store.*"}[5m]
+            (
+                sum by (namespace, job) (
+                  rate(
+                    grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-store.*"}[5m]
+                  )
                 )
-              )
-            /
-              sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-store.*"}[5m]))
+              /
+                sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-store.*"}[5m]))
+            )
           *
             100
         >
@@ -535,11 +565,13 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosstorebuckethighoperationfailures
         summary: Thanos Store Bucket is failing to execute operations.
       expr: |2-
-              sum by (namespace, job) (
-                rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-store.*"}[5m])
-              )
-            /
-              sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
+            (
+                sum by (namespace, job) (
+                  rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-store.*"}[5m])
+                )
+              /
+                sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
+            )
           *
             100
         >
@@ -618,13 +650,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulehighruleevaluationfailures
         summary: Thanos Rule is failing to evaluate rules.
       expr: |2-
-              sum by (namespace, job, instance) (
-                rate(prometheus_rule_evaluation_failures_total{job=~"thanos-ruler.*"}[5m])
-              )
-            /
-              sum by (namespace, job, instance) (
-                rate(prometheus_rule_evaluations_total{job=~"thanos-ruler.*"}[5m])
-              )
+            (
+                sum by (namespace, job, instance) (
+                  rate(prometheus_rule_evaluation_failures_total{job=~"thanos-ruler.*"}[5m])
+                )
+              /
+                sum by (namespace, job, instance) (
+                  rate(prometheus_rule_evaluations_total{job=~"thanos-ruler.*"}[5m])
+                )
+            )
           *
             100
         >
@@ -677,13 +711,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulegrpcerrorrate
         summary: Thanos Rule is failing to handle grpc requests.
       expr: |2-
-              sum by (namespace, job, instance) (
-                rate(
-                  grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-ruler.*"}[5m]
+            (
+                sum by (namespace, job, instance) (
+                  rate(
+                    grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-ruler.*"}[5m]
+                  )
                 )
-              )
-            /
-              sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"thanos-ruler.*"}[5m]))
+              /
+                sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"thanos-ruler.*"}[5m]))
+            )
           *
             100
         >
@@ -715,13 +751,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulequeryhighdnsfailures
         summary: Thanos Rule is having high number of DNS failures.
       expr: |2-
-              sum by (namespace, job, instance) (
-                rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-ruler.*"}[5m])
-              )
-            /
-              sum by (namespace, job, instance) (
-                rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
-              )
+            (
+                sum by (namespace, job, instance) (
+                  rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-ruler.*"}[5m])
+                )
+              /
+                sum by (namespace, job, instance) (
+                  rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
+                )
+            )
           *
             100
         >
@@ -738,13 +776,15 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulealertmanagerhighdnsfailures
         summary: Thanos Rule is having high number of DNS failures.
       expr: |2-
-              sum by (namespace, job, instance) (
-                rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-ruler.*"}[5m])
-              )
-            /
-              sum by (namespace, job, instance) (
-                rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
-              )
+            (
+                sum by (namespace, job, instance) (
+                  rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-ruler.*"}[5m])
+                )
+              /
+                sum by (namespace, job, instance) (
+                  rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
+                )
+            )
           *
             100
         >
@@ -761,17 +801,21 @@ spec:
         runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulenoevaluationfor10intervals
         summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
       expr: |2-
-            time()
-          -
-            max by (namespace, job, instance, group) (
-              prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"thanos-ruler.*"}
-            )
+          (
+              time()
+            -
+              max by (namespace, job, instance, group) (
+                prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"thanos-ruler.*"}
+              )
+          )
         >
-            10
-          *
-            max by (namespace, job, instance, group) (
-              prometheus_rule_group_interval_seconds{job=~"thanos-ruler.*"}
-            )
+          (
+              10
+            *
+              max by (namespace, job, instance, group) (
+                prometheus_rule_group_interval_seconds{job=~"thanos-ruler.*"}
+              )
+          )
       for: 5m
       labels:
         service: thanos

--- a/examples/rules/prometheus/alertmanager/alertmanager-rules.yaml
+++ b/examples/rules/prometheus/alertmanager/alertmanager-rules.yaml
@@ -37,9 +37,11 @@ groups:
       runbook: https://github.com/prometheus/alertmanager/blob/main/doc/alertmanager-mixin/README.md#alertmanagerfailedtosendalerts
       summary: An Alertmanager instance failed to send notifications.
     expr: |2-
-          rate(alertmanager_notifications_failed_total{job="alertmanager"}[15m])
-        / ignoring (reason) group_left ()
-          rate(alertmanager_notifications_total{job="alertmanager"}[15m])
+        (
+            rate(alertmanager_notifications_failed_total{job="alertmanager"}[15m])
+          / ignoring (reason) group_left ()
+            rate(alertmanager_notifications_total{job="alertmanager"}[15m])
+        )
       >
         0.01
     for: 5m
@@ -112,9 +114,11 @@ groups:
       summary: Half or more of the Alertmanager instances within the same cluster
         are down.
     expr: |2-
-          count by (job) (avg_over_time(up{job="alertmanager"}[5m]) < 0.5)
-        /
-          count by (job) (up{job="alertmanager"})
+        (
+            count by (job) (avg_over_time(up{job="alertmanager"}[5m]) < 0.5)
+          /
+            count by (job) (up{job="alertmanager"})
+        )
       >=
         0.5
     for: 5m
@@ -130,9 +134,11 @@ groups:
       summary: Half or more of the Alertmanager instances within the same cluster
         are crashlooping.
     expr: |2-
-          count by (job) (changes(process_start_time_seconds{job="alertmanager"}[10m]) > 4)
-        /
-          count by (job) (up{job="alertmanager"})
+        (
+            count by (job) (changes(process_start_time_seconds{job="alertmanager"}[10m]) > 4)
+          /
+            count by (job) (up{job="alertmanager"})
+        )
       >=
         0.5
     for: 5m

--- a/examples/rules/prometheus/thanos/thanos-rules.yaml
+++ b/examples/rules/prometheus/thanos/thanos-rules.yaml
@@ -107,11 +107,13 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanoscompacthighcompactionfailures
       summary: Thanos Compact is failing to execute compactions.
     expr: |2-
-            sum by (namespace, job) (
-              rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m])
-            )
-          /
-            sum by (namespace, job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
+          (
+              sum by (namespace, job) (
+                rate(thanos_compact_group_compactions_failures_total{job=~"thanos-compact.*"}[5m])
+              )
+            /
+              sum by (namespace, job) (rate(thanos_compact_group_compactions_total{job=~"thanos-compact.*"}[5m]))
+          )
         *
           100
       >
@@ -128,11 +130,13 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanoscompactbuckethighoperationfailures
       summary: Thanos Compact Bucket is having a high number of operation failures.
     expr: |2-
-            sum by (namespace, job) (
-              rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m])
-            )
-          /
-            sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
+          (
+              sum by (namespace, job) (
+                rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-compact.*"}[5m])
+              )
+            /
+              sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-compact.*"}[5m]))
+          )
         *
           100
       >
@@ -149,11 +153,13 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanoscompacthasnotrun
       summary: Thanos Compact has not uploaded anything for last 24 hours.
     expr: |2-
-              time()
-            -
-              max by (namespace, job) (
-                max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}[1d])
-              )
+            (
+                time()
+              -
+                max by (namespace, job) (
+                  max_over_time(thanos_objstore_bucket_last_successful_upload_time{job=~"thanos-compact.*"}[1d])
+                )
+            )
           /
             60
         /
@@ -174,11 +180,13 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosqueryhttprequestqueryerrorratehigh
       summary: Thanos Query is failing to handle requests.
     expr: |2-
-            sum by (namespace, job) (
-              rate(http_requests_total{code=~"5..",handler="query",job=~"thanos-query.*"}[5m])
-            )
-          /
-            sum by (namespace, job) (rate(http_requests_total{handler="query",job=~"thanos-query.*"}[5m]))
+          (
+              sum by (namespace, job) (
+                rate(http_requests_total{code=~"5..",handler="query",job=~"thanos-query.*"}[5m])
+              )
+            /
+              sum by (namespace, job) (rate(http_requests_total{handler="query",job=~"thanos-query.*"}[5m]))
+          )
         *
           100
       >
@@ -195,13 +203,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosquerygrpcservererrorrate
       summary: Thanos Query is failing to handle requests.
     expr: |2-
-            sum by (namespace, job) (
-              rate(
-                grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-query.*"}[5m]
+          (
+              sum by (namespace, job) (
+                rate(
+                  grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-query.*"}[5m]
+                )
               )
-            )
-          /
-            sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
+            /
+              sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-query.*"}[5m]))
+          )
         *
           100
       >
@@ -218,9 +228,11 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosquerygrpcclienterrorrate
       summary: Thanos Query is failing to send requests.
     expr: |2-
-            sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code!="OK",job=~"thanos-query.*"}[5m]))
-          /
-            sum by (namespace, job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
+          (
+              sum by (namespace, job) (rate(grpc_client_handled_total{grpc_code!="OK",job=~"thanos-query.*"}[5m]))
+            /
+              sum by (namespace, job) (rate(grpc_client_started_total{job=~"thanos-query.*"}[5m]))
+          )
         *
           100
       >
@@ -237,11 +249,13 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosqueryhighdnsfailures
       summary: Thanos Query is having high number of DNS failures.
     expr: |2-
-            sum by (namespace, job) (
-              rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m])
-            )
-          /
-            sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+          (
+              sum by (namespace, job) (
+                rate(thanos_query_store_apis_dns_failures_total{job=~"thanos-query.*"}[5m])
+              )
+            /
+              sum by (namespace, job) (rate(thanos_query_store_apis_dns_lookups_total{job=~"thanos-query.*"}[5m]))
+          )
         *
           100
       >
@@ -286,13 +300,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivehttprequesterrorratehigh
       summary: Thanos Receive is failing to handle requests.
     expr: |2-
-            sum by (namespace, job) (
-              rate(http_requests_total{code=~"5..",handler="receive",job=~"thanos-receive-router.*"}[5m])
-            )
-          /
-            sum by (namespace, job) (
-              rate(http_requests_total{handler="receive",job=~"thanos-receive-router.*"}[5m])
-            )
+          (
+              sum by (namespace, job) (
+                rate(http_requests_total{code=~"5..",handler="receive",job=~"thanos-receive-router.*"}[5m])
+              )
+            /
+              sum by (namespace, job) (
+                rate(http_requests_total{handler="receive",job=~"thanos-receive-router.*"}[5m])
+              )
+          )
         *
           100
       >
@@ -337,21 +353,27 @@ groups:
     expr: |2-
         thanos_receive_replication_factor > 1
       and
-              sum by (namespace, job) (
-                rate(thanos_receive_replications_total{job=~"thanos-receive-router.*",result="error"}[5m])
+        (
+              (
+                  sum by (namespace, job) (
+                    rate(thanos_receive_replications_total{job=~"thanos-receive-router.*",result="error"}[5m])
+                  )
+                /
+                  sum by (namespace, job) (
+                    rate(thanos_receive_replications_total{job=~"thanos-receive-router.*"}[5m])
+                  )
               )
-            /
-              sum by (namespace, job) (
-                rate(thanos_receive_replications_total{job=~"thanos-receive-router.*"}[5m])
+            >
+              (
+                  max by (namespace, job) (
+                    floor(thanos_receive_replication_factor{job=~"thanos-receive-router.*"} + 1 / 2)
+                  )
+                /
+                  max by (namespace, job) (thanos_receive_hashring_nodes{job=~"thanos-receive-router.*"})
               )
-          >
-              max by (namespace, job) (
-                floor(thanos_receive_replication_factor{job=~"thanos-receive-router.*"} + 1 / 2)
-              )
-            /
-              max by (namespace, job) (thanos_receive_hashring_nodes{job=~"thanos-receive-router.*"})
-        *
-          100
+          *
+            100
+        )
     for: 5m
     labels:
       service: thanos
@@ -364,13 +386,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivehighforwardrequestfailures
       summary: Thanos Receive is failing to forward requests.
     expr: |2-
-            sum by (namespace, job) (
-              rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*",result="error"}[5m])
-            )
-          /
-            sum by (namespace, job) (
-              rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*"}[5m])
-            )
+          (
+              sum by (namespace, job) (
+                rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*",result="error"}[5m])
+              )
+            /
+              sum by (namespace, job) (
+                rate(thanos_receive_forward_requests_total{job=~"thanos-receive-router.*"}[5m])
+              )
+          )
         *
           100
       >
@@ -387,13 +411,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivehighhashringfilerefreshfailures
       summary: Thanos Receive is failing to refresh hasring file.
     expr: |2-
-          sum by (namespace, job) (
-            rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive-router.*"}[5m])
-          )
-        /
-          sum by (namespace, job) (
-            rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive-router.*"}[5m])
-          )
+        (
+            sum by (namespace, job) (
+              rate(thanos_receive_hashrings_file_errors_total{job=~"thanos-receive-router.*"}[5m])
+            )
+          /
+            sum by (namespace, job) (
+              rate(thanos_receive_hashrings_file_refreshes_total{job=~"thanos-receive-router.*"}[5m])
+            )
+        )
       >
         0
     for: 15m
@@ -425,13 +451,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivenoupload
       summary: Thanos Receive has not uploaded latest data to object storage.
     expr: |2-
-        up{job=~"thanos-receive-ingester.*"} - 1
+        (up{job=~"thanos-receive-ingester.*"} - 1)
       + on (namespace, job, instance)
-          sum by (namespace, job, instance) (
-            increase(thanos_shipper_uploads_total{job=~"thanos-receive-ingester.*"}[3h])
-          )
-        ==
-          0
+        (
+            sum by (namespace, job, instance) (
+              increase(thanos_shipper_uploads_total{job=~"thanos-receive-ingester.*"}[3h])
+            )
+          ==
+            0
+        )
     for: 3h
     labels:
       service: thanos
@@ -501,13 +529,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosstoregrpcerrorrate
       summary: Thanos Store is failing to handle gRPC requests.
     expr: |2-
-            sum by (namespace, job) (
-              rate(
-                grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-store.*"}[5m]
+          (
+              sum by (namespace, job) (
+                rate(
+                  grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-store.*"}[5m]
+                )
               )
-            )
-          /
-            sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-store.*"}[5m]))
+            /
+              sum by (namespace, job) (rate(grpc_server_started_total{job=~"thanos-store.*"}[5m]))
+          )
         *
           100
       >
@@ -524,11 +554,13 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosstorebuckethighoperationfailures
       summary: Thanos Store Bucket is failing to execute operations.
     expr: |2-
-            sum by (namespace, job) (
-              rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-store.*"}[5m])
-            )
-          /
-            sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
+          (
+              sum by (namespace, job) (
+                rate(thanos_objstore_bucket_operation_failures_total{job=~"thanos-store.*"}[5m])
+              )
+            /
+              sum by (namespace, job) (rate(thanos_objstore_bucket_operations_total{job=~"thanos-store.*"}[5m]))
+          )
         *
           100
       >
@@ -607,13 +639,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulehighruleevaluationfailures
       summary: Thanos Rule is failing to evaluate rules.
     expr: |2-
-            sum by (namespace, job, instance) (
-              rate(prometheus_rule_evaluation_failures_total{job=~"thanos-ruler.*"}[5m])
-            )
-          /
-            sum by (namespace, job, instance) (
-              rate(prometheus_rule_evaluations_total{job=~"thanos-ruler.*"}[5m])
-            )
+          (
+              sum by (namespace, job, instance) (
+                rate(prometheus_rule_evaluation_failures_total{job=~"thanos-ruler.*"}[5m])
+              )
+            /
+              sum by (namespace, job, instance) (
+                rate(prometheus_rule_evaluations_total{job=~"thanos-ruler.*"}[5m])
+              )
+          )
         *
           100
       >
@@ -666,13 +700,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulegrpcerrorrate
       summary: Thanos Rule is failing to handle grpc requests.
     expr: |2-
-            sum by (namespace, job, instance) (
-              rate(
-                grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-ruler.*"}[5m]
+          (
+              sum by (namespace, job, instance) (
+                rate(
+                  grpc_server_handled_total{grpc_code=~"Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded",job=~"thanos-ruler.*"}[5m]
+                )
               )
-            )
-          /
-            sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"thanos-ruler.*"}[5m]))
+            /
+              sum by (namespace, job, instance) (rate(grpc_server_started_total{job=~"thanos-ruler.*"}[5m]))
+          )
         *
           100
       >
@@ -704,13 +740,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulequeryhighdnsfailures
       summary: Thanos Rule is having high number of DNS failures.
     expr: |2-
-            sum by (namespace, job, instance) (
-              rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-ruler.*"}[5m])
-            )
-          /
-            sum by (namespace, job, instance) (
-              rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
-            )
+          (
+              sum by (namespace, job, instance) (
+                rate(thanos_rule_query_apis_dns_failures_total{job=~"thanos-ruler.*"}[5m])
+              )
+            /
+              sum by (namespace, job, instance) (
+                rate(thanos_rule_query_apis_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
+              )
+          )
         *
           100
       >
@@ -727,13 +765,15 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulealertmanagerhighdnsfailures
       summary: Thanos Rule is having high number of DNS failures.
     expr: |2-
-            sum by (namespace, job, instance) (
-              rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-ruler.*"}[5m])
-            )
-          /
-            sum by (namespace, job, instance) (
-              rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
-            )
+          (
+              sum by (namespace, job, instance) (
+                rate(thanos_rule_alertmanagers_dns_failures_total{job=~"thanos-ruler.*"}[5m])
+              )
+            /
+              sum by (namespace, job, instance) (
+                rate(thanos_rule_alertmanagers_dns_lookups_total{job=~"thanos-ruler.*"}[5m])
+              )
+          )
         *
           100
       >
@@ -750,17 +790,21 @@ groups:
       runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosrulenoevaluationfor10intervals
       summary: Thanos Rule has rule groups that did not evaluate for 10 intervals.
     expr: |2-
-          time()
-        -
-          max by (namespace, job, instance, group) (
-            prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"thanos-ruler.*"}
-          )
+        (
+            time()
+          -
+            max by (namespace, job, instance, group) (
+              prometheus_rule_group_last_evaluation_timestamp_seconds{job=~"thanos-ruler.*"}
+            )
+        )
       >
-          10
-        *
-          max by (namespace, job, instance, group) (
-            prometheus_rule_group_interval_seconds{job=~"thanos-ruler.*"}
-          )
+        (
+            10
+          *
+            max by (namespace, job, instance, group) (
+              prometheus_rule_group_interval_seconds{job=~"thanos-ruler.*"}
+            )
+        )
     for: 5m
     labels:
       service: thanos

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/perses/plugins/statchart v0.11.1
 	github.com/perses/plugins/table v0.7.1
 	github.com/perses/plugins/timeserieschart v0.11.1
-	github.com/perses/promql-builder v0.2.1-0.20251110140620-19229f7152d4
+	github.com/perses/promql-builder v0.2.1-0.20251203103153-a3bca1892a7b
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.87.0
 	github.com/prometheus/prometheus v0.307.3
 	gopkg.in/yaml.v3 v3.0.1
@@ -20,6 +20,8 @@ require (
 )
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 )
@@ -55,7 +57,7 @@ require (
 	github.com/perses/common v0.28.0 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.67.2 // indirect
+	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,8 @@ github.com/perses/plugins/table v0.0.0-20250709083656-34e29fed0083 h1:JB1BR9IYmC
 github.com/perses/plugins/table v0.0.0-20250709083656-34e29fed0083/go.mod h1:gmmyiOzCxX+ixPOtsy0S2Ufb+F7f7cK49dmaI5UxOzc=
 github.com/perses/plugins/timeserieschart v0.11.1 h1:PQDdi2gG8Wy5aXVYqrfJ+bJ7ROw3q0F65/EN616Fj+o=
 github.com/perses/plugins/timeserieschart v0.11.1/go.mod h1:tlSYzWZJK7ehmC7tlaOo+4Lfkzs5CM9rzV4rGCx4o9Y=
-github.com/perses/promql-builder v0.2.1-0.20251110140620-19229f7152d4 h1:LO3yL/h03HCG4abpEeGInCjm21+7WXbFmWqcOZx1YNE=
-github.com/perses/promql-builder v0.2.1-0.20251110140620-19229f7152d4/go.mod h1:5O4fblt5Ui928jxpw7KtbRiSKt0x37QDycDPTGA0JRM=
+github.com/perses/promql-builder v0.2.1-0.20251203103153-a3bca1892a7b h1:W+0LE4409siSZixU7MMHcFsBtSHzgVeaIlTVBPfG/8E=
+github.com/perses/promql-builder v0.2.1-0.20251203103153-a3bca1892a7b/go.mod h1:Vh6Ffwh4IYrNE7bJbMlF1JQsReex42hiMT0Yw8BYrIQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -177,8 +177,8 @@ github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.67.2 h1:PcBAckGFTIHt2+L3I33uNRTlKTplNzFctXcWhPyAEN8=
-github.com/prometheus/common v0.67.2/go.mod h1:63W3KZb1JOKgcjlIr64WW/LvFGAqKPj0atm+knVGEko=
+github.com/prometheus/common v0.67.4 h1:yR3NqWO1/UyO1w2PhUvXlGQs/PtFmoveVO0KZ4+Lvsc=
+github.com/prometheus/common v0.67.4/go.mod h1:gP0fq6YjjNCLssJCQp0yk4M8W6ikLURwkdd/YKtTbyI=
 github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEoIwkU+A6qos=
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=

--- a/pkg/rules/alertmanager/alertmanager.go
+++ b/pkg/rules/alertmanager/alertmanager.go
@@ -247,30 +247,32 @@ func (a AlertmanagerRulesConfig) AlertmanagerRulesGroup() []rulegroup.Option {
 			"AlertmanagerFailedToSendAlerts",
 			alerting.Expr(
 				promqlbuilder.Gtr(
-					promqlbuilder.Div(
-						promqlbuilder.Rate(
-							matrix.New(
-								vector.New(
-									vector.WithMetricName("alertmanager_notifications_failed_total"),
-									vector.WithLabelMatchers(
-										label.New("job").Equal(a.AlertmanagerServiceSelector),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Div(
+							promqlbuilder.Rate(
+								matrix.New(
+									vector.New(
+										vector.WithMetricName("alertmanager_notifications_failed_total"),
+										vector.WithLabelMatchers(
+											label.New("job").Equal(a.AlertmanagerServiceSelector),
+										),
 									),
+									matrix.WithRange(15*time.Minute),
 								),
-								matrix.WithRange(15*time.Minute),
 							),
-						),
-						promqlbuilder.Rate(
-							matrix.New(
-								vector.New(
-									vector.WithMetricName("alertmanager_notifications_total"),
-									vector.WithLabelMatchers(
-										label.New("job").Equal(a.AlertmanagerServiceSelector),
+							promqlbuilder.Rate(
+								matrix.New(
+									vector.New(
+										vector.WithMetricName("alertmanager_notifications_total"),
+										vector.WithLabelMatchers(
+											label.New("job").Equal(a.AlertmanagerServiceSelector),
+										),
 									),
+									matrix.WithRange(15*time.Minute),
 								),
-								matrix.WithRange(15*time.Minute),
 							),
-						),
-					).Ignoring("reason").GroupLeft(),
+						).Ignoring("reason").GroupLeft(),
+					),
 					promqlbuilder.NewNumber(0.01),
 				),
 			),
@@ -458,31 +460,33 @@ func (a AlertmanagerRulesConfig) AlertmanagerRulesGroup() []rulegroup.Option {
 			"AlertmanagerClusterDown",
 			alerting.Expr(
 				promqlbuilder.Gte(
-					promqlbuilder.Div(
-						promqlbuilder.Count(
-							promqlbuilder.Lss(
-								promqlbuilder.AvgOverTime(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("up"),
-											vector.WithLabelMatchers(
-												label.New("job").Equal(a.AlertmanagerServiceSelector),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Div(
+							promqlbuilder.Count(
+								promqlbuilder.Lss(
+									promqlbuilder.AvgOverTime(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("up"),
+												vector.WithLabelMatchers(
+													label.New("job").Equal(a.AlertmanagerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
+									),
+									promqlbuilder.NewNumber(0.5),
+								),
+							).By("job"),
+							promqlbuilder.Count(
+								vector.New(
+									vector.WithMetricName("up"),
+									vector.WithLabelMatchers(
+										label.New("job").Equal(a.AlertmanagerServiceSelector),
 									),
 								),
-								promqlbuilder.NewNumber(0.5),
-							),
-						).By("job"),
-						promqlbuilder.Count(
-							vector.New(
-								vector.WithMetricName("up"),
-								vector.WithLabelMatchers(
-									label.New("job").Equal(a.AlertmanagerServiceSelector),
-								),
-							),
-						).By("job"),
+							).By("job"),
+						),
 					),
 					promqlbuilder.NewNumber(0.5),
 				),
@@ -514,31 +518,33 @@ func (a AlertmanagerRulesConfig) AlertmanagerRulesGroup() []rulegroup.Option {
 			"AlertmanagerClusterCrashlooping",
 			alerting.Expr(
 				promqlbuilder.Gte(
-					promqlbuilder.Div(
-						promqlbuilder.Count(
-							promqlbuilder.Gtr(
-								promqlbuilder.Changes(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("process_start_time_seconds"),
-											vector.WithLabelMatchers(
-												label.New("job").Equal(a.AlertmanagerServiceSelector),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Div(
+							promqlbuilder.Count(
+								promqlbuilder.Gtr(
+									promqlbuilder.Changes(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("process_start_time_seconds"),
+												vector.WithLabelMatchers(
+													label.New("job").Equal(a.AlertmanagerServiceSelector),
+												),
 											),
+											matrix.WithRange(10*time.Minute),
 										),
-										matrix.WithRange(10*time.Minute),
+									),
+									promqlbuilder.NewNumber(4),
+								),
+							).By("job"),
+							promqlbuilder.Count(
+								vector.New(
+									vector.WithMetricName("up"),
+									vector.WithLabelMatchers(
+										label.New("job").Equal(a.AlertmanagerServiceSelector),
 									),
 								),
-								promqlbuilder.NewNumber(4),
-							),
-						).By("job"),
-						promqlbuilder.Count(
-							vector.New(
-								vector.WithMetricName("up"),
-								vector.WithLabelMatchers(
-									label.New("job").Equal(a.AlertmanagerServiceSelector),
-								),
-							),
-						).By("job"),
+							).By("job"),
+						),
 					),
 					promqlbuilder.NewNumber(0.5),
 				),

--- a/pkg/rules/thanos/thanos.go
+++ b/pkg/rules/thanos/thanos.go
@@ -573,33 +573,35 @@ func (t ThanosRulesConfig) ThanosCompactGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_compact_group_compactions_failures_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.CompactServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_compact_group_compactions_failures_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.CompactServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_compact_group_compactions_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.CompactServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_compact_group_compactions_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.CompactServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -634,33 +636,35 @@ func (t ThanosRulesConfig) ThanosCompactGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_objstore_bucket_operation_failures_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.CompactServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_objstore_bucket_operation_failures_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.CompactServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_objstore_bucket_operations_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.CompactServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_objstore_bucket_operations_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.CompactServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -696,21 +700,23 @@ func (t ThanosRulesConfig) ThanosCompactGroup() []rulegroup.Option {
 				promqlbuilder.Gtr(
 					promqlbuilder.Div(
 						promqlbuilder.Div(
-							promqlbuilder.Sub(
-								promqlbuilder.Time(),
-								promqlbuilder.Max(
-									promqlbuilder.MaxOverTime(
-										matrix.New(
-											vector.New(
-												vector.WithMetricName("thanos_objstore_bucket_last_successful_upload_time"),
-												vector.WithLabelMatchers(
-													label.New("job").EqualRegexp(t.CompactServiceSelector),
+							promqlbuilder.Parenthesis(
+								promqlbuilder.Sub(
+									promqlbuilder.Time(),
+									promqlbuilder.Max(
+										promqlbuilder.MaxOverTime(
+											matrix.New(
+												vector.New(
+													vector.WithMetricName("thanos_objstore_bucket_last_successful_upload_time"),
+													vector.WithLabelMatchers(
+														label.New("job").EqualRegexp(t.CompactServiceSelector),
+													),
 												),
+												matrix.WithRange(24*time.Hour),
 											),
-											matrix.WithRange(24*time.Hour),
 										),
-									),
-								).By("namespace", "job"),
+									).By("namespace", "job"),
+								),
 							),
 							promqlbuilder.NewNumber(60),
 						),
@@ -752,36 +758,38 @@ func (t ThanosRulesConfig) ThanosQueryGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("http_requests_total"),
-											vector.WithLabelMatchers(
-												label.New("code").EqualRegexp("5.."),
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
-												label.New("handler").Equal("query"),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("http_requests_total"),
+												vector.WithLabelMatchers(
+													label.New("code").EqualRegexp("5.."),
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+													label.New("handler").Equal("query"),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("http_requests_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
-												label.New("handler").Equal("query"),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("http_requests_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+													label.New("handler").Equal("query"),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -816,34 +824,36 @@ func (t ThanosRulesConfig) ThanosQueryGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_server_handled_total"),
-											vector.WithLabelMatchers(
-												label.New("grpc_code").EqualRegexp("Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"),
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_server_handled_total"),
+												vector.WithLabelMatchers(
+													label.New("grpc_code").EqualRegexp("Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"),
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_server_started_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_server_started_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -878,34 +888,36 @@ func (t ThanosRulesConfig) ThanosQueryGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_client_handled_total"),
-											vector.WithLabelMatchers(
-												label.New("grpc_code").NotEqual("OK"),
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_client_handled_total"),
+												vector.WithLabelMatchers(
+													label.New("grpc_code").NotEqual("OK"),
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_client_started_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_client_started_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -940,33 +952,35 @@ func (t ThanosRulesConfig) ThanosQueryGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_query_store_apis_dns_failures_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_query_store_apis_dns_failures_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_query_store_apis_dns_lookups_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.QueryServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_query_store_apis_dns_lookups_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.QueryServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -1072,36 +1086,38 @@ func (t ThanosRulesConfig) ThanosReceiveGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("http_requests_total"),
-											vector.WithLabelMatchers(
-												label.New("code").EqualRegexp("5.."),
-												label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
-												label.New("handler").Equal("receive"),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("http_requests_total"),
+												vector.WithLabelMatchers(
+													label.New("code").EqualRegexp("5.."),
+													label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+													label.New("handler").Equal("receive"),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("http_requests_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
-												label.New("handler").Equal("receive"),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("http_requests_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+													label.New("handler").Equal("receive"),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -1207,65 +1223,71 @@ func (t ThanosRulesConfig) ThanosReceiveGroup() []rulegroup.Option {
 						),
 						promqlbuilder.NewNumber(1),
 					),
-					promqlbuilder.Mul(
-						promqlbuilder.Gtr(
-							promqlbuilder.Div(
-								promqlbuilder.Sum(
-									promqlbuilder.Rate(
-										matrix.New(
-											vector.New(
-												vector.WithMetricName("thanos_receive_replications_total"),
-												vector.WithLabelMatchers(
-													label.New("result").Equal("error"),
-													label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
-												),
-											),
-											matrix.WithRange(5*time.Minute),
-										),
-									),
-								).By("namespace", "job"),
-								promqlbuilder.Sum(
-									promqlbuilder.Rate(
-										matrix.New(
-											vector.New(
-												vector.WithMetricName("thanos_receive_replications_total"),
-												vector.WithLabelMatchers(
-													label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
-												),
-											),
-											matrix.WithRange(5*time.Minute),
-										),
-									),
-								).By("namespace", "job"),
-							),
-							promqlbuilder.Div(
-								promqlbuilder.Max(
-									promqlbuilder.Floor(
-										promqlbuilder.Div(
-											promqlbuilder.Add(
-												vector.New(
-													vector.WithMetricName("thanos_receive_replication_factor"),
-													vector.WithLabelMatchers(
-														label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Mul(
+							promqlbuilder.Gtr(
+								promqlbuilder.Parenthesis(
+									promqlbuilder.Div(
+										promqlbuilder.Sum(
+											promqlbuilder.Rate(
+												matrix.New(
+													vector.New(
+														vector.WithMetricName("thanos_receive_replications_total"),
+														vector.WithLabelMatchers(
+															label.New("result").Equal("error"),
+															label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+														),
 													),
+													matrix.WithRange(5*time.Minute),
 												),
-												promqlbuilder.NewNumber(1),
 											),
-											promqlbuilder.NewNumber(2),
-										),
+										).By("namespace", "job"),
+										promqlbuilder.Sum(
+											promqlbuilder.Rate(
+												matrix.New(
+													vector.New(
+														vector.WithMetricName("thanos_receive_replications_total"),
+														vector.WithLabelMatchers(
+															label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+														),
+													),
+													matrix.WithRange(5*time.Minute),
+												),
+											),
+										).By("namespace", "job"),
 									),
-								).By("namespace", "job"),
-								promqlbuilder.Max(
-									vector.New(
-										vector.WithMetricName("thanos_receive_hashring_nodes"),
-										vector.WithLabelMatchers(
-											label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
-										),
+								),
+								promqlbuilder.Parenthesis(
+									promqlbuilder.Div(
+										promqlbuilder.Max(
+											promqlbuilder.Floor(
+												promqlbuilder.Div(
+													promqlbuilder.Add(
+														vector.New(
+															vector.WithMetricName("thanos_receive_replication_factor"),
+															vector.WithLabelMatchers(
+																label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+															),
+														),
+														promqlbuilder.NewNumber(1),
+													),
+													promqlbuilder.NewNumber(2),
+												),
+											),
+										).By("namespace", "job"),
+										promqlbuilder.Max(
+											vector.New(
+												vector.WithMetricName("thanos_receive_hashring_nodes"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+												),
+											),
+										).By("namespace", "job"),
 									),
-								).By("namespace", "job"),
+								),
 							),
+							promqlbuilder.NewNumber(100),
 						),
-						promqlbuilder.NewNumber(100),
 					),
 				),
 			),
@@ -1297,34 +1319,36 @@ func (t ThanosRulesConfig) ThanosReceiveGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_receive_forward_requests_total"),
-											vector.WithLabelMatchers(
-												label.New("result").Equal("error"),
-												label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_receive_forward_requests_total"),
+												vector.WithLabelMatchers(
+													label.New("result").Equal("error"),
+													label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_receive_forward_requests_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_receive_forward_requests_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -1358,33 +1382,35 @@ func (t ThanosRulesConfig) ThanosReceiveGroup() []rulegroup.Option {
 			"ThanosReceiveHighHashringFileRefreshFailures",
 			alerting.Expr(
 				promqlbuilder.Gtr(
-					promqlbuilder.Div(
-						promqlbuilder.Sum(
-							promqlbuilder.Rate(
-								matrix.New(
-									vector.New(
-										vector.WithMetricName("thanos_receive_hashrings_file_errors_total"),
-										vector.WithLabelMatchers(
-											label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Div(
+							promqlbuilder.Sum(
+								promqlbuilder.Rate(
+									matrix.New(
+										vector.New(
+											vector.WithMetricName("thanos_receive_hashrings_file_errors_total"),
+											vector.WithLabelMatchers(
+												label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+											),
 										),
+										matrix.WithRange(5*time.Minute),
 									),
-									matrix.WithRange(5*time.Minute),
 								),
-							),
-						).By("namespace", "job"),
-						promqlbuilder.Sum(
-							promqlbuilder.Rate(
-								matrix.New(
-									vector.New(
-										vector.WithMetricName("thanos_receive_hashrings_file_refreshes_total"),
-										vector.WithLabelMatchers(
-											label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+							).By("namespace", "job"),
+							promqlbuilder.Sum(
+								promqlbuilder.Rate(
+									matrix.New(
+										vector.New(
+											vector.WithMetricName("thanos_receive_hashrings_file_refreshes_total"),
+											vector.WithLabelMatchers(
+												label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+											),
 										),
+										matrix.WithRange(5*time.Minute),
 									),
-									matrix.WithRange(5*time.Minute),
 								),
-							),
-						).By("namespace", "job"),
+							).By("namespace", "job"),
+						),
 					),
 					promqlbuilder.NewNumber(0),
 				),
@@ -1454,30 +1480,34 @@ func (t ThanosRulesConfig) ThanosReceiveGroup() []rulegroup.Option {
 			"ThanosReceiveNoUpload",
 			alerting.Expr(
 				promqlbuilder.Add(
-					promqlbuilder.Sub(
-						vector.New(
-							vector.WithMetricName("up"),
-							vector.WithLabelMatchers(
-								label.New("job").EqualRegexp(t.ReceiveIngesterServiceSelector),
-							),
-						),
-						promqlbuilder.NewNumber(1),
-					),
-					promqlbuilder.Eqlc(
-						promqlbuilder.Sum(
-							promqlbuilder.Increase(
-								matrix.New(
-									vector.New(
-										vector.WithMetricName("thanos_shipper_uploads_total"),
-										vector.WithLabelMatchers(
-											label.New("job").EqualRegexp(t.ReceiveIngesterServiceSelector),
-										),
-									),
-									matrix.WithRange(3*time.Hour),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Sub(
+							vector.New(
+								vector.WithMetricName("up"),
+								vector.WithLabelMatchers(
+									label.New("job").EqualRegexp(t.ReceiveIngesterServiceSelector),
 								),
 							),
-						).By("namespace", "job", "instance"),
-						promqlbuilder.NewNumber(0),
+							promqlbuilder.NewNumber(1),
+						),
+					),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Eqlc(
+							promqlbuilder.Sum(
+								promqlbuilder.Increase(
+									matrix.New(
+										vector.New(
+											vector.WithMetricName("thanos_shipper_uploads_total"),
+											vector.WithLabelMatchers(
+												label.New("job").EqualRegexp(t.ReceiveIngesterServiceSelector),
+											),
+										),
+										matrix.WithRange(3*time.Hour),
+									),
+								),
+							).By("namespace", "job", "instance"),
+							promqlbuilder.NewNumber(0),
+						),
 					),
 				).On("namespace", "job", "instance"),
 			),
@@ -1649,34 +1679,36 @@ func (t ThanosRulesConfig) ThanosStoreGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_server_handled_total"),
-											vector.WithLabelMatchers(
-												label.New("grpc_code").EqualRegexp("Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"),
-												label.New("job").EqualRegexp(t.StoreServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_server_handled_total"),
+												vector.WithLabelMatchers(
+													label.New("grpc_code").EqualRegexp("Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"),
+													label.New("job").EqualRegexp(t.StoreServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_server_started_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.StoreServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_server_started_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.StoreServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -1711,33 +1743,35 @@ func (t ThanosRulesConfig) ThanosStoreGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_objstore_bucket_operation_failures_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.StoreServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_objstore_bucket_operation_failures_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.StoreServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_objstore_bucket_operations_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.StoreServiceSelector),
+								).By("namespace", "job"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_objstore_bucket_operations_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.StoreServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job"),
+								).By("namespace", "job"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -1927,33 +1961,35 @@ func (t ThanosRulesConfig) ThanosRuleGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("prometheus_rule_evaluation_failures_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("prometheus_rule_evaluation_failures_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("prometheus_rule_evaluations_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+								).By("namespace", "job", "instance"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("prometheus_rule_evaluations_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
+								).By("namespace", "job", "instance"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -2076,34 +2112,36 @@ func (t ThanosRulesConfig) ThanosRuleGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_server_handled_total"),
-											vector.WithLabelMatchers(
-												label.New("grpc_code").EqualRegexp("Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"),
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_server_handled_total"),
+												vector.WithLabelMatchers(
+													label.New("grpc_code").EqualRegexp("Unknown|ResourceExhausted|Internal|Unavailable|DataLoss|DeadlineExceeded"),
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("grpc_server_started_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+								).By("namespace", "job", "instance"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("grpc_server_started_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
+								).By("namespace", "job", "instance"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -2176,33 +2214,35 @@ func (t ThanosRulesConfig) ThanosRuleGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_rule_query_apis_dns_failures_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_rule_query_apis_dns_failures_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_rule_query_apis_dns_lookups_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+								).By("namespace", "job", "instance"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_rule_query_apis_dns_lookups_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
+								).By("namespace", "job", "instance"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -2237,33 +2277,35 @@ func (t ThanosRulesConfig) ThanosRuleGroup() []rulegroup.Option {
 			alerting.Expr(
 				promqlbuilder.Gtr(
 					promqlbuilder.Mul(
-						promqlbuilder.Div(
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_rule_alertmanagers_dns_failures_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Div(
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_rule_alertmanagers_dns_failures_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
-							promqlbuilder.Sum(
-								promqlbuilder.Rate(
-									matrix.New(
-										vector.New(
-											vector.WithMetricName("thanos_rule_alertmanagers_dns_lookups_total"),
-											vector.WithLabelMatchers(
-												label.New("job").EqualRegexp(t.RulerServiceSelector),
+								).By("namespace", "job", "instance"),
+								promqlbuilder.Sum(
+									promqlbuilder.Rate(
+										matrix.New(
+											vector.New(
+												vector.WithMetricName("thanos_rule_alertmanagers_dns_lookups_total"),
+												vector.WithLabelMatchers(
+													label.New("job").EqualRegexp(t.RulerServiceSelector),
+												),
 											),
+											matrix.WithRange(5*time.Minute),
 										),
-										matrix.WithRange(5*time.Minute),
 									),
-								),
-							).By("namespace", "job", "instance"),
+								).By("namespace", "job", "instance"),
+							),
 						),
 						promqlbuilder.NewNumber(100),
 					),
@@ -2297,27 +2339,31 @@ func (t ThanosRulesConfig) ThanosRuleGroup() []rulegroup.Option {
 			"ThanosRuleNoEvaluationFor10Intervals",
 			alerting.Expr(
 				promqlbuilder.Gtr(
-					promqlbuilder.Sub(
-						promqlbuilder.Time(),
-						promqlbuilder.Max(
-							vector.New(
-								vector.WithMetricName("prometheus_rule_group_last_evaluation_timestamp_seconds"),
-								vector.WithLabelMatchers(
-									label.New("job").EqualRegexp(t.RulerServiceSelector),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Sub(
+							promqlbuilder.Time(),
+							promqlbuilder.Max(
+								vector.New(
+									vector.WithMetricName("prometheus_rule_group_last_evaluation_timestamp_seconds"),
+									vector.WithLabelMatchers(
+										label.New("job").EqualRegexp(t.RulerServiceSelector),
+									),
 								),
-							),
-						).By("namespace", "job", "instance", "group"),
+							).By("namespace", "job", "instance", "group"),
+						),
 					),
-					promqlbuilder.Mul(
-						promqlbuilder.NewNumber(10),
-						promqlbuilder.Max(
-							vector.New(
-								vector.WithMetricName("prometheus_rule_group_interval_seconds"),
-								vector.WithLabelMatchers(
-									label.New("job").EqualRegexp(t.RulerServiceSelector),
+					promqlbuilder.Parenthesis(
+						promqlbuilder.Mul(
+							promqlbuilder.NewNumber(10),
+							promqlbuilder.Max(
+								vector.New(
+									vector.WithMetricName("prometheus_rule_group_interval_seconds"),
+									vector.WithLabelMatchers(
+										label.New("job").EqualRegexp(t.RulerServiceSelector),
+									),
 								),
-							),
-						).By("namespace", "job", "instance", "group"),
+							).By("namespace", "job", "instance", "group"),
+						),
 					),
 				),
 			),


### PR DESCRIPTION
This commit fixes a lot of expressions where we miss parenthesis, which changes the mathematical meaning of those alerts.

Use newly added Parenthesis function to do so https://github.com/perses/promql-builder/pull/28