### PR TITLE
fix(k8s): Remove cadvisor metrics_path from "cluster" variable matcher

### DIFF
--- a/examples/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.yaml
@@ -843,5 +843,5 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
 status: {}

--- a/examples/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.yaml
@@ -1388,5 +1388,5 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
 status: {}

--- a/examples/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.yaml
@@ -583,7 +583,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.yaml
@@ -1320,7 +1320,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-node-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-node-resources-overview.yaml
@@ -520,7 +520,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.yaml
@@ -404,7 +404,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.yaml
@@ -1202,7 +1202,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.yaml
@@ -546,7 +546,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.yaml
@@ -801,7 +801,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.yaml
@@ -1086,7 +1086,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.yaml
+++ b/examples/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.yaml
@@ -992,7 +992,7 @@ spec:
             name: prometheus-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/examples/dashboards/perses/kubernetes/kubernetes-cluster-networking-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-cluster-networking-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
     panels:
         "0_0":

--- a/examples/dashboards/perses/kubernetes/kubernetes-cluster-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-cluster-resources-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
     panels:
         "0_0":

--- a/examples/dashboards/perses/kubernetes/kubernetes-namespace-networking-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-namespace-networking-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-namespace-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-namespace-resources-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-node-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-node-resources-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-pod-networking-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-pod-networking-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-pod-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-pod-resources-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-workload-networking-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-workload-networking-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-workload-ns-networking-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-workload-ns-networking-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-workload-ns-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-workload-ns-resources-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/examples/dashboards/perses/kubernetes/kubernetes-workload-resources-overview.yaml
+++ b/examples/dashboards/perses/kubernetes/kubernetes-workload-resources-overview.yaml
@@ -24,7 +24,7 @@ spec:
                         name: prometheus-datasource
                     labelName: cluster
                     matchers:
-                        - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+                        - up{job="kubelet"}
             name: cluster
         - kind: ListVariable
           spec:

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-networking-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-cluster-resources-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-networking-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-namespace-resources-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-node-resources-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-node-resources-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-networking-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-pod-resources-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-networking-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-networking-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-ns-resources-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.json
+++ b/jsonnet/dashboards/operator/kubernetes/kubernetes-workload-resources-overview.json
@@ -34,7 +34,7 @@
               },
               "labelName": "cluster",
               "matchers": [
-                "up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"}"
+                "up{job=\"kubelet\"}"
               ]
             }
           },

--- a/jsonnet/examples/kubernetes-cluster-networking-overview.yaml
+++ b/jsonnet/examples/kubernetes-cluster-networking-overview.yaml
@@ -835,5 +835,5 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
 status: {}

--- a/jsonnet/examples/kubernetes-cluster-resources-overview.yaml
+++ b/jsonnet/examples/kubernetes-cluster-resources-overview.yaml
@@ -1383,5 +1383,5 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
 status: {}

--- a/jsonnet/examples/kubernetes-namespace-networking-overview.yaml
+++ b/jsonnet/examples/kubernetes-namespace-networking-overview.yaml
@@ -575,7 +575,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-namespace-resources-overview.yaml
+++ b/jsonnet/examples/kubernetes-namespace-resources-overview.yaml
@@ -1312,7 +1312,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-node-resources-overview.yaml
+++ b/jsonnet/examples/kubernetes-node-resources-overview.yaml
@@ -515,7 +515,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-pod-networking-overview.yaml
+++ b/jsonnet/examples/kubernetes-pod-networking-overview.yaml
@@ -403,7 +403,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-pod-resources-overview.yaml
+++ b/jsonnet/examples/kubernetes-pod-resources-overview.yaml
@@ -1197,7 +1197,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-workload-networking-overview.yaml
+++ b/jsonnet/examples/kubernetes-workload-networking-overview.yaml
@@ -536,7 +536,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-workload-ns-networking-overview.yaml
+++ b/jsonnet/examples/kubernetes-workload-ns-networking-overview.yaml
@@ -791,7 +791,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-workload-ns-resources-overview.yaml
+++ b/jsonnet/examples/kubernetes-workload-ns-resources-overview.yaml
@@ -1076,7 +1076,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/jsonnet/examples/kubernetes-workload-resources-overview.yaml
+++ b/jsonnet/examples/kubernetes-workload-resources-overview.yaml
@@ -985,7 +985,7 @@ spec:
             name: custom-datasource
           labelName: cluster
           matchers:
-          - up{job="kubelet", metrics_path="/metrics/cadvisor"}
+          - up{job="kubelet"}
   - kind: ListVariable
     spec:
       allowAllValue: false

--- a/pkg/dashboards/kubernetes/compute_resources/cluster.go
+++ b/pkg/dashboards/kubernetes/compute_resources/cluster.go
@@ -122,7 +122,7 @@ func BuildKubernetesClusterOverview(project string, datasource string, clusterLa
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/compute_resources/namespace.go
+++ b/pkg/dashboards/kubernetes/compute_resources/namespace.go
@@ -115,7 +115,7 @@ func BuildKubernetesNamespaceOverview(project string,
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/compute_resources/node.go
+++ b/pkg/dashboards/kubernetes/compute_resources/node.go
@@ -56,7 +56,7 @@ func BuildKubernetesNodeResourcesOverview(project string, datasource string, clu
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/compute_resources/pod.go
+++ b/pkg/dashboards/kubernetes/compute_resources/pod.go
@@ -109,7 +109,7 @@ func BuildKubernetesPodOverview(project string, datasource string, clusterLabelN
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/compute_resources/workload.go
+++ b/pkg/dashboards/kubernetes/compute_resources/workload.go
@@ -92,7 +92,7 @@ func BuildKubernetesWorkloadOverview(project string, datasource string, clusterL
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/compute_resources/workload_namespace.go
+++ b/pkg/dashboards/kubernetes/compute_resources/workload_namespace.go
@@ -92,7 +92,7 @@ func BuildKubernetesWorkloadNamespaceOverview(project string, datasource string,
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/networking/cluster.go
+++ b/pkg/dashboards/kubernetes/networking/cluster.go
@@ -78,7 +78,7 @@ func BuildKubernetesClusterOverview(project string, datasource string, clusterLa
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/networking/namespace_by_pod.go
+++ b/pkg/dashboards/kubernetes/networking/namespace_by_pod.go
@@ -60,7 +60,7 @@ func BuildKubernetesNamespaceByPodOverview(project string, datasource string, cl
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/networking/namespace_by_workload.go
+++ b/pkg/dashboards/kubernetes/networking/namespace_by_workload.go
@@ -69,7 +69,7 @@ func BuildKubernetesNamespaceByWorkloadOverview(project string, datasource strin
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/networking/pod.go
+++ b/pkg/dashboards/kubernetes/networking/pod.go
@@ -52,7 +52,7 @@ func BuildKubernetesPodOverview(project string, datasource string, clusterLabelN
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),

--- a/pkg/dashboards/kubernetes/networking/workload.go
+++ b/pkg/dashboards/kubernetes/networking/workload.go
@@ -61,7 +61,7 @@ func BuildKubernetesWorkloadOverview(project string, datasource string, clusterL
 		dashboard.AddVariable("cluster",
 			listVar.List(
 				labelValuesVar.PrometheusLabelValues("cluster",
-					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+", metrics_path=\"/metrics/cadvisor\"}"),
+					labelValuesVar.Matchers("up{"+panels.GetKubeletMatcher()+"}"),
 					dashboards.AddVariableDatasource(datasource),
 				),
 				listVar.DisplayName("cluster"),


### PR DESCRIPTION
Fixes: https://github.com/perses/community-mixins/issues/223
This PR allows setting a different job name than "kubelet" for cadvisor metrics without breaking the cluster variable.
Thus, honoring the default value of the job name for cadvisor metrics: https://github.com/perses/community-mixins/blob/78636bb66492e999155c2793c8dcb8c365085702/pkg/panels/kubernetes/globals.go#L12
