### PR TITLE
fix(dashboards): support "All" option for instance variable in node-exporter

### DIFF
--- a/examples/dashboards/operator/node-exporter/node-exporter-nodes.yaml
+++ b/examples/dashboards/operator/node-exporter/node-exporter-nodes.yaml
@@ -113,11 +113,11 @@ spec:
                     -
                       sum without (mode) (
                         rate(
-                          node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval]
+                          node_cpu_seconds_total{instance=~"$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval]
                         )
                       )
                   / ignoring (cpu) group_left ()
-                    count without (cpu, mode) (node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                    count without (cpu, mode) (node_cpu_seconds_total{instance=~"$instance",job="node",mode="idle"})
                 seriesNameFormat: '{{device}} - CPU - Usage'
     "0_1":
       kind: Panel
@@ -142,7 +142,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: node_load1{instance="$instance",job="node"}
+                query: node_load1{instance=~"$instance",job="node"}
                 seriesNameFormat: CPU - 1m Average
         - kind: TimeSeriesQuery
           spec:
@@ -152,7 +152,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: node_load5{instance="$instance",job="node"}
+                query: node_load5{instance=~"$instance",job="node"}
                 seriesNameFormat: CPU - 5m Average
         - kind: TimeSeriesQuery
           spec:
@@ -162,7 +162,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: node_load15{instance="$instance",job="node"}
+                query: node_load15{instance=~"$instance",job="node"}
                 seriesNameFormat: CPU - 15m Average
         - kind: TimeSeriesQuery
           spec:
@@ -172,7 +172,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: count(node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                query: count(node_cpu_seconds_total{instance=~"$instance",job="node",mode="idle"})
                 seriesNameFormat: CPU - Logical Cores
     "1_0":
       kind: Panel
@@ -201,7 +201,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: node_memory_Buffers_bytes{instance="$instance",job="node"}
+                query: node_memory_Buffers_bytes{instance=~"$instance",job="node"}
                 seriesNameFormat: Memory - Buffers
         - kind: TimeSeriesQuery
           spec:
@@ -211,7 +211,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: node_memory_Cached_bytes{instance="$instance",job="node"}
+                query: node_memory_Cached_bytes{instance=~"$instance",job="node"}
                 seriesNameFormat: Memory - Cached
         - kind: TimeSeriesQuery
           spec:
@@ -221,7 +221,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: node_memory_MemFree_bytes{instance="$instance",job="node"}
+                query: node_memory_MemFree_bytes{instance=~"$instance",job="node"}
                 seriesNameFormat: Memory - Free
     "1_1":
       kind: Panel
@@ -255,9 +255,9 @@ spec:
                 query: |2-
                     100
                   -
-                      avg(node_memory_MemAvailable_bytes{instance="$instance",job="node"})
+                      avg(node_memory_MemAvailable_bytes{instance=~"$instance",job="node"})
                     /
-                      avg(node_memory_MemTotal_bytes{instance="$instance",job="node"}) * 100
+                      avg(node_memory_MemTotal_bytes{instance=~"$instance",job="node"}) * 100
                 seriesNameFormat: Memory - Usage
     "2_0":
       kind: Panel
@@ -285,7 +285,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                query: rate(node_disk_read_bytes_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - Usage'
         - kind: TimeSeriesQuery
           spec:
@@ -295,7 +295,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                query: rate(node_disk_io_time_seconds_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - Written'
     "2_1":
       kind: Panel
@@ -323,7 +323,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: prometheus-datasource
-                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                query: rate(node_disk_io_time_seconds_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - IO Time'
     "3_0":
       kind: Panel
@@ -353,7 +353,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   rate(
-                    node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval]
+                    node_network_receive_bytes_total{device!="lo",instance=~"$instance",job="node"}[$__rate_interval]
                   )
                 seriesNameFormat: '{{device}} - Network - Received'
     "3_1":
@@ -384,7 +384,7 @@ spec:
                   name: prometheus-datasource
                 query: |-
                   rate(
-                    node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval]
+                    node_network_receive_bytes_total{device!="lo",instance=~"$instance",job="node"}[$__rate_interval]
                   )
                 seriesNameFormat: '{{device}} - Network - Transmitted'
   variables:

--- a/examples/dashboards/perses/node-exporter/node-exporter-nodes.yaml
+++ b/examples/dashboards/perses/node-exporter/node-exporter-nodes.yaml
@@ -58,11 +58,11 @@ spec:
                                       -
                                         sum without (mode) (
                                           rate(
-                                            node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval]
+                                            node_cpu_seconds_total{instance=~"$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval]
                                           )
                                         )
                                     / ignoring (cpu) group_left ()
-                                      count without (cpu, mode) (node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                                      count without (cpu, mode) (node_cpu_seconds_total{instance=~"$instance",job="node",mode="idle"})
                                 seriesNameFormat: '{{device}} - CPU - Usage'
         "0_1":
             kind: Panel
@@ -87,7 +87,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: node_load1{instance="$instance",job="node"}
+                                query: node_load1{instance=~"$instance",job="node"}
                                 seriesNameFormat: CPU - 1m Average
                     - kind: TimeSeriesQuery
                       spec:
@@ -97,7 +97,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: node_load5{instance="$instance",job="node"}
+                                query: node_load5{instance=~"$instance",job="node"}
                                 seriesNameFormat: CPU - 5m Average
                     - kind: TimeSeriesQuery
                       spec:
@@ -107,7 +107,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: node_load15{instance="$instance",job="node"}
+                                query: node_load15{instance=~"$instance",job="node"}
                                 seriesNameFormat: CPU - 15m Average
                     - kind: TimeSeriesQuery
                       spec:
@@ -117,7 +117,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: count(node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                                query: count(node_cpu_seconds_total{instance=~"$instance",job="node",mode="idle"})
                                 seriesNameFormat: CPU - Logical Cores
         "1_0":
             kind: Panel
@@ -146,7 +146,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: node_memory_Buffers_bytes{instance="$instance",job="node"}
+                                query: node_memory_Buffers_bytes{instance=~"$instance",job="node"}
                                 seriesNameFormat: Memory - Buffers
                     - kind: TimeSeriesQuery
                       spec:
@@ -156,7 +156,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: node_memory_Cached_bytes{instance="$instance",job="node"}
+                                query: node_memory_Cached_bytes{instance=~"$instance",job="node"}
                                 seriesNameFormat: Memory - Cached
                     - kind: TimeSeriesQuery
                       spec:
@@ -166,7 +166,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: node_memory_MemFree_bytes{instance="$instance",job="node"}
+                                query: node_memory_MemFree_bytes{instance=~"$instance",job="node"}
                                 seriesNameFormat: Memory - Free
         "1_1":
             kind: Panel
@@ -200,9 +200,9 @@ spec:
                                 query: |4-
                                       100
                                     -
-                                        avg(node_memory_MemAvailable_bytes{instance="$instance",job="node"})
+                                        avg(node_memory_MemAvailable_bytes{instance=~"$instance",job="node"})
                                       /
-                                        avg(node_memory_MemTotal_bytes{instance="$instance",job="node"}) * 100
+                                        avg(node_memory_MemTotal_bytes{instance=~"$instance",job="node"}) * 100
                                 seriesNameFormat: Memory - Usage
         "2_0":
             kind: Panel
@@ -230,7 +230,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                                query: rate(node_disk_read_bytes_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Disk - Usage'
                     - kind: TimeSeriesQuery
                       spec:
@@ -240,7 +240,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                                query: rate(node_disk_io_time_seconds_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Disk - Written'
         "2_1":
             kind: Panel
@@ -268,7 +268,7 @@ spec:
                                 datasource:
                                     kind: PrometheusDatasource
                                     name: prometheus-datasource
-                                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                                query: rate(node_disk_io_time_seconds_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                                 seriesNameFormat: '{{device}} - Disk - IO Time'
         "3_0":
             kind: Panel
@@ -298,7 +298,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     rate(
-                                      node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval]
+                                      node_network_receive_bytes_total{device!="lo",instance=~"$instance",job="node"}[$__rate_interval]
                                     )
                                 seriesNameFormat: '{{device}} - Network - Received'
         "3_1":
@@ -329,7 +329,7 @@ spec:
                                     name: prometheus-datasource
                                 query: |-
                                     rate(
-                                      node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval]
+                                      node_network_receive_bytes_total{device!="lo",instance=~"$instance",job="node"}[$__rate_interval]
                                     )
                                 seriesNameFormat: '{{device}} - Network - Transmitted'
     layouts:

--- a/jsonnet/dashboards/operator/node-exporter/node-exporter-nodes.json
+++ b/jsonnet/dashboards/operator/node-exporter/node-exporter-nodes.json
@@ -78,7 +78,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "    1\n  -\n    sum without (mode) (\n      rate(\n        node_cpu_seconds_total{instance=\"$instance\",job=\"node\",mode=~\"idle|iowait|steal\"}[$__rate_interval]\n      )\n    )\n/ ignoring (cpu) group_left ()\n  count without (cpu, mode) (node_cpu_seconds_total{instance=\"$instance\",job=\"node\",mode=\"idle\"})",
+                    "query": "    1\n  -\n    sum without (mode) (\n      rate(\n        node_cpu_seconds_total{instance=~\"$instance\",job=\"node\",mode=~\"idle|iowait|steal\"}[$__rate_interval]\n      )\n    )\n/ ignoring (cpu) group_left ()\n  count without (cpu, mode) (node_cpu_seconds_total{instance=~\"$instance\",job=\"node\",mode=\"idle\"})",
                     "seriesNameFormat": "{{device}} - CPU - Usage"
                   }
                 }
@@ -117,7 +117,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "node_load1{instance=\"$instance\",job=\"node\"}",
+                    "query": "node_load1{instance=~\"$instance\",job=\"node\"}",
                     "seriesNameFormat": "CPU - 1m Average"
                   }
                 }
@@ -133,7 +133,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "node_load5{instance=\"$instance\",job=\"node\"}",
+                    "query": "node_load5{instance=~\"$instance\",job=\"node\"}",
                     "seriesNameFormat": "CPU - 5m Average"
                   }
                 }
@@ -149,7 +149,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "node_load15{instance=\"$instance\",job=\"node\"}",
+                    "query": "node_load15{instance=~\"$instance\",job=\"node\"}",
                     "seriesNameFormat": "CPU - 15m Average"
                   }
                 }
@@ -165,7 +165,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "count(node_cpu_seconds_total{instance=\"$instance\",job=\"node\",mode=\"idle\"})",
+                    "query": "count(node_cpu_seconds_total{instance=~\"$instance\",job=\"node\",mode=\"idle\"})",
                     "seriesNameFormat": "CPU - Logical Cores"
                   }
                 }
@@ -210,7 +210,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "node_memory_Buffers_bytes{instance=\"$instance\",job=\"node\"}",
+                    "query": "node_memory_Buffers_bytes{instance=~\"$instance\",job=\"node\"}",
                     "seriesNameFormat": "Memory - Buffers"
                   }
                 }
@@ -226,7 +226,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "node_memory_Cached_bytes{instance=\"$instance\",job=\"node\"}",
+                    "query": "node_memory_Cached_bytes{instance=~\"$instance\",job=\"node\"}",
                     "seriesNameFormat": "Memory - Cached"
                   }
                 }
@@ -242,7 +242,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "node_memory_MemFree_bytes{instance=\"$instance\",job=\"node\"}",
+                    "query": "node_memory_MemFree_bytes{instance=~\"$instance\",job=\"node\"}",
                     "seriesNameFormat": "Memory - Free"
                   }
                 }
@@ -292,7 +292,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "  100\n-\n    avg(node_memory_MemAvailable_bytes{instance=\"$instance\",job=\"node\"})\n  /\n    avg(node_memory_MemTotal_bytes{instance=\"$instance\",job=\"node\"}) * 100",
+                    "query": "  100\n-\n    avg(node_memory_MemAvailable_bytes{instance=~\"$instance\",job=\"node\"})\n  /\n    avg(node_memory_MemTotal_bytes{instance=~\"$instance\",job=\"node\"}) * 100",
                     "seriesNameFormat": "Memory - Usage"
                   }
                 }
@@ -336,7 +336,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "rate(node_disk_read_bytes_total{device!=\"\",instance=\"$instance\",job=\"node\"}[$__rate_interval])",
+                    "query": "rate(node_disk_read_bytes_total{device!=\"\",instance=~\"$instance\",job=\"node\"}[$__rate_interval])",
                     "seriesNameFormat": "{{device}} - Disk - Usage"
                   }
                 }
@@ -352,7 +352,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "rate(node_disk_io_time_seconds_total{device!=\"\",instance=\"$instance\",job=\"node\"}[$__rate_interval])",
+                    "query": "rate(node_disk_io_time_seconds_total{device!=\"\",instance=~\"$instance\",job=\"node\"}[$__rate_interval])",
                     "seriesNameFormat": "{{device}} - Disk - Written"
                   }
                 }
@@ -396,7 +396,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "rate(node_disk_io_time_seconds_total{device!=\"\",instance=\"$instance\",job=\"node\"}[$__rate_interval])",
+                    "query": "rate(node_disk_io_time_seconds_total{device!=\"\",instance=~\"$instance\",job=\"node\"}[$__rate_interval])",
                     "seriesNameFormat": "{{device}} - Disk - IO Time"
                   }
                 }
@@ -440,7 +440,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "rate(\n  node_network_receive_bytes_total{device!=\"lo\",instance=\"$instance\",job=\"node\"}[$__rate_interval]\n)",
+                    "query": "rate(\n  node_network_receive_bytes_total{device!=\"lo\",instance=~\"$instance\",job=\"node\"}[$__rate_interval]\n)",
                     "seriesNameFormat": "{{device}} - Network - Received"
                   }
                 }
@@ -484,7 +484,7 @@
                       "kind": "PrometheusDatasource",
                       "name": "prometheus-datasource"
                     },
-                    "query": "rate(\n  node_network_receive_bytes_total{device!=\"lo\",instance=\"$instance\",job=\"node\"}[$__rate_interval]\n)",
+                    "query": "rate(\n  node_network_receive_bytes_total{device!=\"lo\",instance=~\"$instance\",job=\"node\"}[$__rate_interval]\n)",
                     "seriesNameFormat": "{{device}} - Network - Transmitted"
                   }
                 }

--- a/jsonnet/examples/node-exporter-nodes.yaml
+++ b/jsonnet/examples/node-exporter-nodes.yaml
@@ -113,11 +113,11 @@ spec:
                     -
                       sum without (mode) (
                         rate(
-                          node_cpu_seconds_total{instance="$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval]
+                          node_cpu_seconds_total{instance=~"$instance",job="node",mode=~"idle|iowait|steal"}[$__rate_interval]
                         )
                       )
                   / ignoring (cpu) group_left ()
-                    count without (cpu, mode) (node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                    count without (cpu, mode) (node_cpu_seconds_total{instance=~"$instance",job="node",mode="idle"})
                 seriesNameFormat: '{{device}} - CPU - Usage'
     "0_1":
       kind: Panel
@@ -142,7 +142,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: node_load1{instance="$instance",job="node"}
+                query: node_load1{instance=~"$instance",job="node"}
                 seriesNameFormat: CPU - 1m Average
         - kind: TimeSeriesQuery
           spec:
@@ -152,7 +152,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: node_load5{instance="$instance",job="node"}
+                query: node_load5{instance=~"$instance",job="node"}
                 seriesNameFormat: CPU - 5m Average
         - kind: TimeSeriesQuery
           spec:
@@ -162,7 +162,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: node_load15{instance="$instance",job="node"}
+                query: node_load15{instance=~"$instance",job="node"}
                 seriesNameFormat: CPU - 15m Average
         - kind: TimeSeriesQuery
           spec:
@@ -172,7 +172,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: count(node_cpu_seconds_total{instance="$instance",job="node",mode="idle"})
+                query: count(node_cpu_seconds_total{instance=~"$instance",job="node",mode="idle"})
                 seriesNameFormat: CPU - Logical Cores
     "1_0":
       kind: Panel
@@ -201,7 +201,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: node_memory_Buffers_bytes{instance="$instance",job="node"}
+                query: node_memory_Buffers_bytes{instance=~"$instance",job="node"}
                 seriesNameFormat: Memory - Buffers
         - kind: TimeSeriesQuery
           spec:
@@ -211,7 +211,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: node_memory_Cached_bytes{instance="$instance",job="node"}
+                query: node_memory_Cached_bytes{instance=~"$instance",job="node"}
                 seriesNameFormat: Memory - Cached
         - kind: TimeSeriesQuery
           spec:
@@ -221,7 +221,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: node_memory_MemFree_bytes{instance="$instance",job="node"}
+                query: node_memory_MemFree_bytes{instance=~"$instance",job="node"}
                 seriesNameFormat: Memory - Free
     "1_1":
       kind: Panel
@@ -255,9 +255,9 @@ spec:
                 query: |2-
                     100
                   -
-                      avg(node_memory_MemAvailable_bytes{instance="$instance",job="node"})
+                      avg(node_memory_MemAvailable_bytes{instance=~"$instance",job="node"})
                     /
-                      avg(node_memory_MemTotal_bytes{instance="$instance",job="node"}) * 100
+                      avg(node_memory_MemTotal_bytes{instance=~"$instance",job="node"}) * 100
                 seriesNameFormat: Memory - Usage
     "2_0":
       kind: Panel
@@ -285,7 +285,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: rate(node_disk_read_bytes_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                query: rate(node_disk_read_bytes_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - Usage'
         - kind: TimeSeriesQuery
           spec:
@@ -295,7 +295,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                query: rate(node_disk_io_time_seconds_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - Written'
     "2_1":
       kind: Panel
@@ -323,7 +323,7 @@ spec:
                 datasource:
                   kind: PrometheusDatasource
                   name: custom-datasource
-                query: rate(node_disk_io_time_seconds_total{device!="",instance="$instance",job="node"}[$__rate_interval])
+                query: rate(node_disk_io_time_seconds_total{device!="",instance=~"$instance",job="node"}[$__rate_interval])
                 seriesNameFormat: '{{device}} - Disk - IO Time'
     "3_0":
       kind: Panel
@@ -353,7 +353,7 @@ spec:
                   name: custom-datasource
                 query: |-
                   rate(
-                    node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval]
+                    node_network_receive_bytes_total{device!="lo",instance=~"$instance",job="node"}[$__rate_interval]
                   )
                 seriesNameFormat: '{{device}} - Network - Received'
     "3_1":
@@ -384,7 +384,7 @@ spec:
                   name: custom-datasource
                 query: |-
                   rate(
-                    node_network_receive_bytes_total{device!="lo",instance="$instance",job="node"}[$__rate_interval]
+                    node_network_receive_bytes_total{device!="lo",instance=~"$instance",job="node"}[$__rate_interval]
                   )
                 seriesNameFormat: '{{device}} - Network - Transmitted'
   variables:

--- a/pkg/panels/node_exporter/queries.go
+++ b/pkg/panels/node_exporter/queries.go
@@ -37,7 +37,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 								vector.WithLabelMatchers(
 									label.New("job").Equal("node"),
 									label.New("mode").EqualRegexp("idle|iowait|steal"),
-									label.New("instance").Equal("$instance"),
+									label.New("instance").EqualRegexp("$instance"),
 								),
 							),
 							matrix.WithRangeAsVariable("$__rate_interval"),
@@ -51,7 +51,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 					vector.WithLabelMatchers(
 						label.New("job").Equal("node"),
 						label.New("mode").Equal("idle"),
-						label.New("instance").Equal("$instance"),
+						label.New("instance").EqualRegexp("$instance"),
 					),
 				),
 			).Without("cpu", "mode"),
@@ -257,21 +257,21 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 		vector.WithMetricName("node_load1"),
 		vector.WithLabelMatchers(
 			label.New("job").Equal("node"),
-			label.New("instance").Equal("$instance"),
+			label.New("instance").EqualRegexp("$instance"),
 		),
 	),
 	"NodeExporterNodeAverageLoad5": vector.New(
 		vector.WithMetricName("node_load5"),
 		vector.WithLabelMatchers(
 			label.New("job").Equal("node"),
-			label.New("instance").Equal("$instance"),
+			label.New("instance").EqualRegexp("$instance"),
 		),
 	),
 	"NodeExporterNodeAverageLoad15": vector.New(
 		vector.WithMetricName("node_load15"),
 		vector.WithLabelMatchers(
 			label.New("job").Equal("node"),
-			label.New("instance").Equal("$instance"),
+			label.New("instance").EqualRegexp("$instance"),
 		),
 	),
 	"NodeExporterNodeAverageCountCPU": promqlbuilder.Count(
@@ -279,7 +279,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 			vector.WithMetricName("node_cpu_seconds_total"),
 			vector.WithLabelMatchers(
 				label.New("job").Equal("node"),
-				label.New("instance").Equal("$instance"),
+				label.New("instance").EqualRegexp("$instance"),
 				label.New("mode").Equal("idle"),
 			),
 		),
@@ -288,21 +288,21 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 		vector.WithMetricName("node_memory_Buffers_bytes"),
 		vector.WithLabelMatchers(
 			label.New("job").Equal("node"),
-			label.New("instance").Equal("$instance"),
+			label.New("instance").EqualRegexp("$instance"),
 		),
 	),
 	"NodeExporterNodeMemoryUsageBytesCached": vector.New(
 		vector.WithMetricName("node_memory_Cached_bytes"),
 		vector.WithLabelMatchers(
 			label.New("job").Equal("node"),
-			label.New("instance").Equal("$instance"),
+			label.New("instance").EqualRegexp("$instance"),
 		),
 	),
 	"NodeExporterNodeMemoryUsageBytesMemFree": vector.New(
 		vector.WithMetricName("node_memory_MemFree_bytes"),
 		vector.WithLabelMatchers(
 			label.New("job").Equal("node"),
-			label.New("instance").Equal("$instance"),
+			label.New("instance").EqualRegexp("$instance"),
 		),
 	),
 	"NodeExporterNodeMemoryUsagePercentage": promqlbuilder.Sub(
@@ -313,7 +313,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 					vector.WithMetricName("node_memory_MemAvailable_bytes"),
 					vector.WithLabelMatchers(
 						label.New("job").Equal("node"),
-						label.New("instance").Equal("$instance"),
+						label.New("instance").EqualRegexp("$instance"),
 					),
 				),
 			),
@@ -323,7 +323,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 						vector.WithMetricName("node_memory_MemTotal_bytes"),
 						vector.WithLabelMatchers(
 							label.New("job").Equal("node"),
-							label.New("instance").Equal("$instance"),
+							label.New("instance").EqualRegexp("$instance"),
 						),
 					),
 				),
@@ -337,7 +337,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 				vector.WithMetricName("node_disk_read_bytes_total"),
 				vector.WithLabelMatchers(
 					label.New("job").Equal("node"),
-					label.New("instance").Equal("$instance"),
+					label.New("instance").EqualRegexp("$instance"),
 					label.New("device").NotEqual(""),
 				),
 			),
@@ -350,7 +350,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 				vector.WithMetricName("node_disk_io_time_seconds_total"),
 				vector.WithLabelMatchers(
 					label.New("job").Equal("node"),
-					label.New("instance").Equal("$instance"),
+					label.New("instance").EqualRegexp("$instance"),
 					label.New("device").NotEqual(""),
 				),
 			),
@@ -363,7 +363,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 				vector.WithMetricName("node_disk_io_time_seconds_total"),
 				vector.WithLabelMatchers(
 					label.New("job").Equal("node"),
-					label.New("instance").Equal("$instance"),
+					label.New("instance").EqualRegexp("$instance"),
 					label.New("device").NotEqual(""),
 				),
 			),
@@ -376,7 +376,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 				vector.WithMetricName("node_network_receive_bytes_total"),
 				vector.WithLabelMatchers(
 					label.New("job").Equal("node"),
-					label.New("instance").Equal("$instance"),
+					label.New("instance").EqualRegexp("$instance"),
 					label.New("device").NotEqual("lo"),
 				),
 			),
@@ -389,7 +389,7 @@ var NodeExporterCommonPanelQueries = map[string]parser.Expr{
 				vector.WithMetricName("node_network_transmit_bytes_total"),
 				vector.WithLabelMatchers(
 					label.New("job").Equal("node"),
-					label.New("instance").Equal("$instance"),
+					label.New("instance").EqualRegexp("$instance"),
 					label.New("device").NotEqual("lo"),
 				),
 			),


### PR DESCRIPTION

# What this PR does
This PR updates the node-exporter-nodes dashboard to correctly handle the "All" selection for the $instance variable. I have replaced the exact match operator (=) with the regex match operator (=~) in all relevant PromQL queries.

## Why

The current implementation uses {instance="$instance"}, which fails when "All" is selected because the variable expands to a regex pattern (.*). By switching to =~, the dashboard can successfully match all instances or a single instance, resolving the "No data" issue when the "All" option is chosen.

 ## Fixes
https://github.com/perses/community-mixins/issues/257

## Type of change

[x] Bug fix

[ ] New feature (dashboard, panel, rule, etc.)

[ ] Enhancement to existing mixin

[ ] Refactoring (no functional change)

[ ] Documentation

[ ] CI / Build / Tooling

## Checklist

- [x] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
- [x] I have run `make build-dashboards` and verified the generated output
- [x] I have run `make lint` with no new warnings
- [x] I have tested my changes locally
- [x] I have updated documentation if needed


## Additional notes

This change maintains allowMultiple: false to keep the dashboard focused on single-node or cluster-wide views without overcomplicating the visualization with multiple overlapping lines.