### PR TITLE
rules:thanos: Add ThanosReceiveLimitsHit alert

### DIFF
--- a/examples/rules/operator/thanos/thanos-rules.yaml
+++ b/examples/rules/operator/thanos/thanos-rules.yaml
@@ -530,6 +530,23 @@ spec:
       labels:
         service: thanos
         severity: medium
+    - alert: ThanosReceiveLimitsHit
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosreceive
+        description: Thanos Receive {{$labels.job}} in {{$labels.namespace}} is limiting
+          requests for tenant {{$labels.tenant}} due to {{$labels.limit}} limit.
+        runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivelimitshit
+        summary: Thanos Receive is limiting requests.
+      expr: |2-
+          sum by (namespace, job, tenant, limit) (
+            rate(thanos_receive_write_limits_hit_count{job=~"thanos-receive-router.*"}[10m])
+          )
+        >
+          0
+      for: 10m
+      labels:
+        service: thanos
+        severity: medium
   - name: thanos-store
     rules:
     - alert: ThanosStoreGrpcErrorRate

--- a/examples/rules/prometheus/thanos/thanos-rules.yaml
+++ b/examples/rules/prometheus/thanos/thanos-rules.yaml
@@ -519,6 +519,23 @@ groups:
     labels:
       service: thanos
       severity: medium
+  - alert: ThanosReceiveLimitsHit
+    annotations:
+      dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosreceive
+      description: Thanos Receive {{$labels.job}} in {{$labels.namespace}} is limiting
+        requests for tenant {{$labels.tenant}} due to {{$labels.limit}} limit.
+      runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceivelimitshit
+      summary: Thanos Receive is limiting requests.
+    expr: |2-
+        sum by (namespace, job, tenant, limit) (
+          rate(thanos_receive_write_limits_hit_count{job=~"thanos-receive-router.*"}[10m])
+        )
+      >
+        0
+    for: 10m
+    labels:
+      service: thanos
+      severity: medium
 - name: thanos-store
   rules:
   - alert: ThanosStoreGrpcErrorRate

--- a/pkg/rules/thanos/thanos.go
+++ b/pkg/rules/thanos/thanos.go
@@ -55,6 +55,7 @@ const (
 	runbookThanosReceiveLimitsConfigReloadFailure                  = "#thanosreceivelimitsconfigreloadfailure"
 	runbookThanosReceiveLimitsHighMetaMonitoringQueriesFailureRate = "#thanosreceivelimitshighmetamonitoringqueriesfailurerate"
 	runbookThanosReceiveTenantLimitedByHeadSeries                  = "#thanosreceivetenantlimitedbyheadseries"
+	runbookThanosReceiveLimitsHit                                  = "#thanosreceivelimitshit"
 	runbookThanosStoreGrpcErrorRate                                = "#thanosstoregrpcerrorrate"
 	runbookThanosStoreBucketHighOperationFailures                  = "#thanosstorebuckethighoperationfailures"
 	runbookThanosStoreObjstoreOperationLatencyHigh                 = "#thanosstoreobjstoreoperationlatencyhigh"
@@ -1693,6 +1694,49 @@ func (t ThanosRulesConfig) ThanosReceiveGroup() []rulegroup.Option {
 						runbookThanosReceiveTenantLimitedByHeadSeries,
 						"Thanos Receive tenant {{$labels.tenant}} in {{$labels.namespace}} is limited by head series.",
 						"Thanos Receive tenant is limited by head series.",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule(
+			"ThanosReceiveLimitsHit",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Sum(
+						promqlbuilder.Rate(
+							matrix.New(
+								vector.New(
+									vector.WithMetricName("thanos_receive_write_limits_hit_count"),
+									vector.WithLabelMatchers(
+										label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+									),
+								),
+								matrix.WithRange(10*time.Minute),
+							),
+						),
+					).By("namespace", "job", "tenant", "limit"),
+					promqlbuilder.NewNumber(0),
+				),
+			),
+			alerting.For("10m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":  t.ServiceLabelValue,
+						"severity": "medium",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.ReceiveDashboardURL,
+						t.RunbookURL,
+						runbookThanosReceiveLimitsHit,
+						"Thanos Receive {{$labels.job}} in {{$labels.namespace}} is limiting requests for tenant {{$labels.tenant}} due to {{$labels.limit}} limit.",
+						"Thanos Receive is limiting requests.",
 					),
 					t.AdditionalAlertAnnotations,
 				),


### PR DESCRIPTION


# What this PR does

This commit adds an alert for thanos receive component, so that users are notified when a receive instance is limiting a particular tenant and why.

## Why

<!-- Why is this change needed? Link any related issues. -->

Fixes #

## Type of change

- [ ] Bug fix
- [X] New feature (dashboard, panel, rule, etc.)
- [ ] Enhancement to existing mixin
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build / Tooling

## Checklist

- [X] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
- [X] I have run `make build-dashboards` and verified the generated output
- [X] I have run `make lint` with no new warnings
- [X] I have tested my changes locally
- [ ] I have updated documentation if needed

## Additional notes

<!-- Any additional context, screenshots, or information for reviewers. -->
