### PR TITLE
rules: Add a threshold alert for Thanos Receive limits

### DIFF
--- a/examples/rules/operator/thanos/thanos-rules.yaml
+++ b/examples/rules/operator/thanos/thanos-rules.yaml
@@ -513,6 +513,31 @@ spec:
       labels:
         service: thanos
         severity: medium
+    - alert: ThanosReceiveHeadSeriesReachingLimit
+      annotations:
+        dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosreceive
+        description: Thanos Receive tenant {{$labels.tenant}} head series is at {{
+          $value | humanizePercentage }} of the configured limit.
+        runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceiveheadseriesreachinglimit
+        summary: Thanos Receive tenant head series is reaching the configured limit.
+      expr: |2-
+            sum by (tenant) (prometheus_tsdb_head_series{job=~"thanos-receive-ingester.*"})
+          / on (tenant) group_left ()
+            (
+                max by (tenant) (thanos_receive_head_series_limit{job=~"thanos-receive-router.*",tenant!=""} > 0)
+              or on (tenant)
+                (
+                    sum by (tenant) (prometheus_tsdb_head_series{job=~"thanos-receive-ingester.*"}) * 0
+                  + on () group_left ()
+                    max(thanos_receive_head_series_limit{job=~"thanos-receive-router.*",tenant=""} > 0)
+                )
+            )
+        >
+          0.9
+      for: 5m
+      labels:
+        service: thanos
+        severity: warning
     - alert: ThanosReceiveTenantLimitedByHeadSeries
       annotations:
         dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosreceive

--- a/examples/rules/prometheus/thanos/thanos-rules.yaml
+++ b/examples/rules/prometheus/thanos/thanos-rules.yaml
@@ -502,6 +502,31 @@ groups:
     labels:
       service: thanos
       severity: medium
+  - alert: ThanosReceiveHeadSeriesReachingLimit
+    annotations:
+      dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosreceive
+      description: Thanos Receive tenant {{$labels.tenant}} head series is at {{ $value
+        | humanizePercentage }} of the configured limit.
+      runbook: https://github.com/thanos-io/thanos/blob/main/mixin/runbook.md#thanosreceiveheadseriesreachinglimit
+      summary: Thanos Receive tenant head series is reaching the configured limit.
+    expr: |2-
+          sum by (tenant) (prometheus_tsdb_head_series{job=~"thanos-receive-ingester.*"})
+        / on (tenant) group_left ()
+          (
+              max by (tenant) (thanos_receive_head_series_limit{job=~"thanos-receive-router.*",tenant!=""} > 0)
+            or on (tenant)
+              (
+                  sum by (tenant) (prometheus_tsdb_head_series{job=~"thanos-receive-ingester.*"}) * 0
+                + on () group_left ()
+                  max(thanos_receive_head_series_limit{job=~"thanos-receive-router.*",tenant=""} > 0)
+              )
+          )
+      >
+        0.9
+    for: 5m
+    labels:
+      service: thanos
+      severity: warning
   - alert: ThanosReceiveTenantLimitedByHeadSeries
     annotations:
       dashboard: https://demo.perses.dev/projects/perses/dashboards/thanosreceive

--- a/pkg/rules/thanos/thanos.go
+++ b/pkg/rules/thanos/thanos.go
@@ -54,6 +54,7 @@ const (
 	runbookThanosReceiveNoUpload                                   = "#thanosreceivenoupload"
 	runbookThanosReceiveLimitsConfigReloadFailure                  = "#thanosreceivelimitsconfigreloadfailure"
 	runbookThanosReceiveLimitsHighMetaMonitoringQueriesFailureRate = "#thanosreceivelimitshighmetamonitoringqueriesfailurerate"
+	runbookThanosReceiveHeadSeriesReachingLimit                    = "#thanosreceiveheadseriesreachinglimit"
 	runbookThanosReceiveTenantLimitedByHeadSeries                  = "#thanosreceivetenantlimitedbyheadseries"
 	runbookThanosReceiveLimitsHit                                  = "#thanosreceivelimitshit"
 	runbookThanosStoreGrpcErrorRate                                = "#thanosstoregrpcerrorrate"
@@ -1651,6 +1652,89 @@ func (t ThanosRulesConfig) ThanosReceiveGroup() []rulegroup.Option {
 						runbookThanosReceiveLimitsHighMetaMonitoringQueriesFailureRate,
 						"Thanos Receive {{$labels.job}} in {{$labels.namespace}} is failing for {{$value | humanize}}% of meta monitoring queries.",
 						"Thanos Receive has not been able to update the number of head series.",
+					),
+					t.AdditionalAlertAnnotations,
+				),
+			),
+		),
+		rulegroup.AddRule(
+			"ThanosReceiveHeadSeriesReachingLimit",
+			alerting.Expr(
+				promqlbuilder.Gtr(
+					promqlbuilder.Div(
+						promqlbuilder.Sum(
+							vector.New(
+								vector.WithMetricName("prometheus_tsdb_head_series"),
+								vector.WithLabelMatchers(
+									label.New("job").EqualRegexp(t.ReceiveIngesterServiceSelector),
+								),
+							),
+						).By("tenant"),
+						promqlbuilder.Parenthesis(
+							promqlbuilder.Or(
+								promqlbuilder.Max(
+									promqlbuilder.Gtr(
+										vector.New(
+											vector.WithMetricName("thanos_receive_head_series_limit"),
+											vector.WithLabelMatchers(
+												label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+												label.New("tenant").NotEqual(""),
+											),
+										),
+										promqlbuilder.NewNumber(0),
+									),
+								).By("tenant"),
+								promqlbuilder.Parenthesis(
+									promqlbuilder.Add(
+										promqlbuilder.Mul(
+											promqlbuilder.Sum(
+												vector.New(
+													vector.WithMetricName("prometheus_tsdb_head_series"),
+													vector.WithLabelMatchers(
+														label.New("job").EqualRegexp(t.ReceiveIngesterServiceSelector),
+													),
+												),
+											).By("tenant"),
+											promqlbuilder.NewNumber(0),
+										),
+										promqlbuilder.Max(
+											promqlbuilder.Gtr(
+												vector.New(
+													vector.WithMetricName("thanos_receive_head_series_limit"),
+													vector.WithLabelMatchers(
+														label.New("job").EqualRegexp(t.ReceiveRouterServiceSelector),
+														label.New("tenant").Equal(""),
+													),
+												),
+												promqlbuilder.NewNumber(0),
+											),
+										),
+									).On().GroupLeft(),
+								),
+							).On("tenant"),
+						),
+					).On("tenant").GroupLeft(),
+					promqlbuilder.NewNumber(0.9),
+				),
+			),
+			alerting.For("5m"),
+			alerting.Labels(
+				common.MergeMaps(
+					map[string]string{
+						"service":  t.ServiceLabelValue,
+						"severity": "warning",
+					},
+					t.AdditionalAlertLabels,
+				),
+			),
+			alerting.Annotations(
+				common.MergeMaps(
+					common.BuildAnnotations(
+						t.ReceiveDashboardURL,
+						t.RunbookURL,
+						runbookThanosReceiveHeadSeriesReachingLimit,
+						"Thanos Receive tenant {{$labels.tenant}} head series is at {{ $value | humanizePercentage }} of the configured limit.",
+						"Thanos Receive tenant head series is reaching the configured limit.",
 					),
 					t.AdditionalAlertAnnotations,
 				),


### PR DESCRIPTION


# What this PR does

<!-- A brief description of the change. -->
This commit adds a ThanosReceiveHeadSeriesReachingLimit alert that will fire, when 90% threshold of the head series limit is breached.

The alert expr is a bit complex due to the way tenant labels are currently handled with this limit.

## Why

<!-- Why is this change needed? Link any related issues. -->

Fixes #

## Type of change

- [ ] Bug fix
- [ ] New feature (dashboard, panel, rule, etc.)
- [x] Enhancement to existing mixin
- [ ] Refactoring (no functional change)
- [ ] Documentation
- [ ] CI / Build / Tooling

## Checklist

- [ ] All commits have [DCO signoffs](https://github.com/probot/dco#how-it-works)
- [ ] I have run `make build-dashboards` and verified the generated output
- [ ] I have run `make lint` with no new warnings
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed

## Additional notes

<!-- Any additional context, screenshots, or information for reviewers. -->
